### PR TITLE
docs: correct link to ADR in documentation

### DIFF
--- a/edx_django_utils/monitoring/docs/how_tos/add_code_owner_custom_attribute_to_an_ida.rst
+++ b/edx_django_utils/monitoring/docs/how_tos/add_code_owner_custom_attribute_to_an_ida.rst
@@ -48,8 +48,7 @@ If the task is not compatible with additional decorators, you can use the follow
 
 An untested potential alternative to the decorator is documented in the `Code Owner for Celery Tasks ADR`_, should we run into maintenance issues using the decorator.
 
-.. _Code Owner for Celery Tasks ADR: https://github.com/edx/edx-platform/blob/master/lms/djangoapps/monitoring/docs/decisions/0003-code-owner-for-celery-tasks.rst
-
+.. _Code Owner for Celery Tasks ADR: https://github.com/edx/edx-django-utils/blob/master/edx_django_utils/monitoring/docs/decisions/0003-code-owner-for-celery-tasks.rst
 Configuring your app settings
 -----------------------------
 


### PR DESCRIPTION
**Description:**

Fix incorrect link in documentation (was pointing to edx-platform instead of edx-django-utils)


**Reviewers:**
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

