### PR TITLE
Remove usage of deprecated Django Import

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 ----------
 
+[4.4.2] - 2021-12-23
+--------------------
+
+Updated
+_______
+
+* Replaced usage of 'django.conf.urls' with 'django.urls'
+
 [4.4.1] - 2021-12-17
 --------------------
 

--- a/edx_django_utils/plugins/plugin_urls.py
+++ b/edx_django_utils/plugins/plugin_urls.py
@@ -5,8 +5,7 @@ Please remember to expose any new public methods in the `__init__.py` file.
 """
 from logging import getLogger
 
-from django.conf.urls import include
-from django.urls import re_path
+from django.urls import include, re_path
 
 from . import constants, registry, utils
 


### PR DESCRIPTION
`django.conf.urls` has been deprecated in Django 3 in favor of `django.urls`.