### PR TITLE
feat: add CookieMonitoringMiddleware

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,11 +14,19 @@ Change Log
 Unreleased
 ----------
 
+[4.6.0] - 2022-03-16
+--------------------
+
+Added
+~~~~~
+
+* Added ``CookieMonitoringMiddleware`` for monitoring cookie header sizes and cookie sizes.
+
 [4.5.0] - 2022-01-31
 --------------------
 
 Removed
-_______
+~~~~~~~
 
 * Removed Django22, 30 and 31 from CI
 
@@ -26,14 +34,14 @@ _______
 --------------------
 
 Fixed
-_____
+~~~~~
 
 * No longer clear the ``RequestCache`` during the exception-handling phase (wait until response phase)
 
   * It turns out all the ``process_exception`` methods get called until one returns a response, and only *then* do the ``process_response`` methods start getting called. The result was that on exception, some middlewares were unable to use RequestCache'd values in their response phase.
 
 Updated
-_______
+~~~~~~~
 
 * Replaced usage of 'django.conf.urls' with 'django.urls'
 
@@ -41,7 +49,7 @@ _______
 --------------------
 
 Updated
-_______
+~~~~~~~
 
 * Replaced usage of 'django.conf.urls.url()' with 'django.urls.re_path()'
 
@@ -49,7 +57,7 @@ _______
 --------------------
 
 Added
-_______
+~~~~~~~
 
 * Added ``DeploymentMonitoringMiddleware`` to record ``Python`` and ``Django`` versions in NewRelic with each transaction.
 
@@ -57,7 +65,7 @@ _______
 --------------------
 
 Added
-_____
+~~~~~
 
 * Added user and group management utilities.
 
@@ -65,7 +73,7 @@ _____
 --------------------
 
 Added
-_____
+~~~~~
 
 * Added support for Django 3.1 and 3.2
 
@@ -73,12 +81,12 @@ _____
 --------------------
 
 Added
-_____
+~~~~~
 
 * Added mixin for a custom Django admin class which disables CRUD operation on the admin's model.
 
 Added
-_____
+~~~~~
 
 * Script new_relic_nrql_search.py to search the NRQL in New Relic alert policies and dashboards using a supplied regex.
 
@@ -86,17 +94,17 @@ _____
 --------------------
 
 Removed
-_______
+~~~~~~~
 
 * Removed the old location of ``CodeOwnerMonitoringMiddleware``. It had moved in a past commit. Although technically a breaking change, all references in the Open edX platform have already been updated to point to the new location.
 
 Added
-_____
+~~~~~
 
 * Added new ``code_owner_theme`` and ``code_owner_squad`` custom attributes. This is useful in cases where the ``code_owner`` combines a theme and squad name, because monitoring can instead reference ``code_owner_squad`` to be resilient to theme name updates. For the decision doc, see edx_django_utils/monitoring/docs/decisions/0004-code-owner-theme-and-squad.rst.
 
 Updated
-_______
+~~~~~~~
 
 * Misconfigurations of CODE_OWNER_MAPPINGS will now fail fast, rather than just logging. Although technically a breaking change, if CODE_OWNER_MAPPINGS is in use, it is probably correctly configured and this change should be a no-op.
 
@@ -104,7 +112,7 @@ _______
 ---------------------
 
 Added
-_____
+~~~~~
 
 * Added ``pluggable_override`` decorator.
 
@@ -118,7 +126,7 @@ _____
 ---------------------
 
 Removed
-_______
+~~~~~~~
 
 * Dropped support for Python 3.5.
 
@@ -127,12 +135,12 @@ _______
 ---------------------
 
 Added
-_____
+~~~~~
 
 * Added record_exception to monitor caught exceptions.
 
 Updated
-_______
+~~~~~~~
 
 * Added additional details to the `deprecated_monitoring_utils` custom attribute values to make it simpler to track down usage.
 
@@ -140,13 +148,13 @@ _______
 ---------------------
 
 Added
-_____
+~~~~~
 
 * Added set_code_owner_attribute decorator for use with celery tasks.
 * Added set_code_owner_attribute_from_module as an alternative to the decorator.
 
 Updated
-_______
+~~~~~~~
 
 * Cleaned up some of the code owner middleware code. In doing so, renamed custom attribute code_owner_path_module to code_owner_module. This may affect monitoring dashboards. Also slightly changed when error custom attributes are set.
 
@@ -154,18 +162,18 @@ _______
 ---------------------
 
 Added
-_____
+~~~~~
 
 * Added ADR 0004-public-api-and-app-organization.rst to explain a new app organization, which makes use of the public API more consistent.
 
 Updated
-_______
+~~~~~~~
 
 * Applied the new app organization described in th ADR to the monitoring Django app.
 * Moved CachedCustomMonitoringMiddleware, CodeOwnerMonitoringMiddleware, and MonitoringMemoryMiddleware to the public API.
 
 Deprecated
-__________
+~~~~~~~~~~
 
 * Deprecated the old locations of CachedCustomMonitoringMiddleware, CodeOwnerMonitoringMiddleware, and MonitoringMemoryMiddleware.
 * Deprecated various methods from modules that were always meant to be used from the public API.
@@ -182,7 +190,7 @@ __________
   Some method implementations that were available in the public API were moved without adding a deprecated equivalent. These were not found when searching, so hopefully they are only used via the public API, which did not change. This includes functions in ``transactions.py`` and ``code_owner/utils.py``.
 
 Removed
-_______
+~~~~~~~
 
 * Removed the middleware ordering checks. This is not a typical Django feature and it is painful when refactoring.
 
@@ -190,7 +198,7 @@ _______
 ---------------------
 
 Added
-_____
+~~~~~
 
 * Added logging filter classes for users and remote IP addresses to be used by all IDAs. These were moved here from edx-platform.
 
@@ -198,7 +206,7 @@ _____
 --------------------
 
 Updated
-_______
+~~~~~~~
 
 * Exposed existing get_code_owner_from_module via the public api.
 * Fixed get_code_owner_from_module to not require a call to is_code_owner_mappings_configured beforehand.
@@ -209,7 +217,7 @@ _______
 --------------------
 
 Updated
-_______
+~~~~~~~
 
 * Renamed "custom metric" to "custom attribute" throughout the monitoring library. This decision can be read about in the ADR 0002-custom-monitoring-language.rst.  The following have been deprecated:
 
@@ -231,7 +239,7 @@ _______
 --------------------
 
 Updated
-_______
+~~~~~~~
 
 * Upgrade psutil to latest version
 
@@ -239,7 +247,7 @@ _______
 --------------------
 
 Updated
-_______
+~~~~~~~
 
 * Added missing classes to plugins public api. See ``plugins.__init__.py`` for latest api.
 * Updated plugin method names to be more descriptive. See ``plugins.__init__.py`` for latest.
@@ -250,7 +258,7 @@ _______
 --------------------
 
 Updated
-_______
+~~~~~~~
 
 * Exposing all public functions in edx_django_utils/plugins directory in its __init__.py file.
     * this was done to keep inline with standard/pattern used in other packages in edx_django_utils
@@ -259,7 +267,7 @@ _______
 --------------------
 
 Added
-_____
+~~~~~
 
 * Adding Plugin infrastructure
     * Allows IDAs to use plugins
@@ -268,13 +276,13 @@ _____
 --------------------
 
 Added
-_____
+~~~~~
 
 * Improved documentation for CodeOwnerMetricMiddleware, including a how_tos/add_code_owner_custom_metric_to_an_ida.rst for adding it to a new IDA.
 * Added ignore_transaction monitoring utility to ignore transactions we don't want tracked.
 
 Updated
-_______
+~~~~~~~
 
 * Moved transaction-related monitoring code into it's own file. Still exposed through `__init__.py` so it's a non-breaking change.
 
@@ -282,7 +290,7 @@ _______
 --------------------
 
 Updated
-_______
+~~~~~~~
 
 * Added a catch-all capability to CodeOwnerMetricMiddleware when CODE_OWNER_MAPPINGS includes a '*' as a team's module. The catch-all is used only if there is no other match.
 
@@ -290,12 +298,12 @@ _______
 --------------------
 
 Added
-_____
+~~~~~
 
 * Added get_current_transaction for monitoring that returns a transaction object with a name property.
 
 Updated
-_______
+~~~~~~~
 
 * Updated CodeOwnerMetricMiddleware to use NewRelic's current transaction for cases where resolve() doesn't work to determine the code_owner, like for Middleware.
 
@@ -303,130 +311,130 @@ _______
 --------------------
 
 Added
-_____
+~~~~~
 
 * CodeOwnerMetricMiddleware was moved here (from edx-platform) in order to be able to take advantage of the ``code_owner`` metric in other IDAs. For details on this decision, see the `ADR for monitoring code owner`_. See the docstring for more details on usage.
 
 .. _ADR for monitoring code owner: https://github.com/edx/edx-django-utils/blob/master/edx_django_utils/monitoring/docs/decisions/0001-monitoring-by-code-owner.rst
 
 [3.2.3] - 2020-05-30
-------------------------------------------------
+--------------------
 * Removed ceninusepy3 usage.
 
 [3.2.2] - 2020-05-04
-------------------------------------------------
+--------------------
 * Added support for python 3.8 and dropped support for Django versions older than 2.2
 
 [3.2.1] - 2020-04-17
-------------------------------------------------
+--------------------
 
 Changed
-_______
+~~~~~~~
 
 * imported get_cache_key in cache/__init__.py.
 
 [3.2.0] - 2020-04-09
-------------------------------------------------
+--------------------
 
 Added
-_______
+~~~~~~~
 
 * Added get_cache_key utility.
 
 [2.0.1] - 2019-10-09
-------------------------------------------------
+--------------------
 
 Changed
-_______
+~~~~~~~
 
 * Fixed: Updated function tracing to accomodate changes in New Relic's 5.x Agent.
 
 [2.0.0] - 2019-07-07
-------------------------------------------------
+--------------------
 
 Changed
-_______
+~~~~~~~
 
 * Converted Middleware (from old style MIDDLEWARE_CLASSES to MIDDLEWARE).
 * Removed support for Django versions < 1.11
 
 [1.0.1] - 2018-09-07
-------------------------------------------------
+--------------------
 
 Changed
-_______
+~~~~~~~
 
 * Fixed: RequestCache now properly uses thread.local.
 * Fixed: CachedResponse.__repr__ now handles unicode.
 
 [1.0.0] - 2018-08-28
-------------------------------------------------
+--------------------
 
 Added
-_______
+~~~~~~~
 
 * Add ``data`` dict property to better match legacy RequestCache interface.
 
 Changed
-_______
+~~~~~~~
 
 * Change is_hit/is_miss to is_found.
 
 [0.5.1] - 2018-08-17
-------------------------------------------------
+--------------------
 
 Changed
-_______
+~~~~~~~
 
 * Fixed bug in TieredCacheMiddleware dependency declaration.
 
 [0.5.0] - 2018-08-16
-------------------------------------------------
+--------------------
 
 Changed
-_______
+~~~~~~~
 
 * Restored Python 3 support.
 * Refactor/clean-up, including Middleware dependency checking.
 * Docs updates and other cookiecutter updates.
 
 [0.4.1] - 2018-08-10
-------------------------------------------------
+--------------------
 
 Changed
-_______
+~~~~~~~
 
 * Split out TieredCacheMiddleware from RequestCacheMiddleware.
 
 [0.4.0] - 2018-08-10
-------------------------------------------------
+--------------------
 
 Changed
-_______
+~~~~~~~
 
 * Rename CacheUtilsMiddleware to RequestCacheMiddleware.
 
 [0.3.0] - 2018-08-02
-------------------------------------------------
+--------------------
 
 Removed
-_______
+~~~~~~~
 
 * Temporarily dropped Python 3 support to land this.
 
 [0.2.0] - 2018-08-01
-------------------------------------------------
+--------------------
 
 Added
-_____
+~~~~~
 
 * Added cache and monitoring utilities.
 
 
 [0.1.0] - 2018-07-23
-------------------------------------------------
+--------------------
 
 Added
-_____
+~~~~~
 
 * First release on PyPI.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -57,7 +57,7 @@ Updated
 --------------------
 
 Added
-~~~~~~~
+~~~~~
 
 * Added ``DeploymentMonitoringMiddleware`` to record ``Python`` and ``Django`` versions in NewRelic with each transaction.
 
@@ -337,7 +337,7 @@ Changed
 --------------------
 
 Added
-~~~~~~~
+~~~~~
 
 * Added get_cache_key utility.
 

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Development Workflow
 --------------------
 
 One Time Setup
-______________
+~~~~~~~~~~~~~~
 .. code-block::
 
   # clone the repo
@@ -56,7 +56,7 @@ ______________
 
 
 Every time you develop something in this repo
-_____________________________________________
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. code-block::
 
   # Activate the virtualenv.

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,7 +2,7 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "4.5.0"
+__version__ = "4.6.0"
 
 default_app_config = (
     "edx_django_utils.apps.EdxDjangoUtilsConfig"

--- a/edx_django_utils/monitoring/README.rst
+++ b/edx_django_utils/monitoring/README.rst
@@ -20,22 +20,39 @@ Here is how you add the middleware:
 .. code-block::
 
     MIDDLEWARE = (
-        'edx_django_utils.monitoring.DeploymentMonitoringMiddleware',
         'edx_django_utils.cache.middleware.RequestCacheMiddleware',
-        # Generate code ownership attributes. Keep this immediately after RequestCacheMiddleware.
-        ...
-        # Monitoring middleware must come after RequestCacheMiddleware
+
+        # Add monitoring middleware immediately after RequestCacheMiddleware
+        'edx_django_utils.monitoring.DeploymentMonitoringMiddleware',
+        'edx_django_utils.monitoring.CookieMonitoringMiddleware',
         'edx_django_utils.monitoring.CodeOwnerMonitoringMiddleware',
         'edx_django_utils.monitoring.CachedCustomMonitoringMiddleware',
         'edx_django_utils.monitoring.MonitoringMemoryMiddleware',
     )
 
-Monitoring Memory Usage
------------------------
+Cached Custom Monitoring Middleware
+-----------------------------------
 
-In addition to adding the MonitoringMemoryMiddleware, you will need to enable a waffle switch ``edx_django_utils.monitoring.enable_memory_middleware`` to enable the additional monitoring.
+The middleware ``CachedCustomMonitoringMiddleware`` is required to allow certain utility methods, like ``accumulate`` and ``increment``, to work appropriately.
 
 Code Owner Custom Attribute
 ---------------------------
 
-See docstrings for ``CodeOwnerMonitoringMiddleware`` for configuring the ``code_owner`` custom attribute for your IDA.
+See docstring for ``CodeOwnerMonitoringMiddleware`` for configuring the ``code_owner`` custom attribute for your IDA.
+
+Cookie Monitoring Middleware
+----------------------------
+
+See docstring for configuring ``CookieMonitoringMiddleware`` to monitor cookie header size.
+
+Also see ``monitoring/scripts/process_cookie_monitoring_logs.py`` for processing log messages.
+
+Deployment Monitoring Middleware
+--------------------------------
+
+Simply add ``DeploymentMonitoringMiddleware`` to monitor the python and django version of each request. See docstring for details.
+
+Monitoring Memory Usage
+-----------------------
+
+In addition to adding the MonitoringMemoryMiddleware, you will need to enable a waffle switch ``edx_django_utils.monitoring.enable_memory_middleware`` to enable the additional monitoring.

--- a/edx_django_utils/monitoring/__init__.py
+++ b/edx_django_utils/monitoring/__init__.py
@@ -11,6 +11,7 @@ from .internal.code_owner.utils import (
 )
 from .internal.middleware import (
     CachedCustomMonitoringMiddleware,
+    CookieMonitoringMiddleware,
     DeploymentMonitoringMiddleware,
     MonitoringMemoryMiddleware
 )

--- a/edx_django_utils/monitoring/internal/middleware.py
+++ b/edx_django_utils/monitoring/internal/middleware.py
@@ -6,12 +6,14 @@ At this time, monitoring details can only be reported to New Relic.
 """
 import logging
 import platform
+import random
 import warnings
 from uuid import uuid4
 
 import django
 import psutil
 import waffle  # pylint: disable=invalid-django-waffle-import
+from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
 
 from edx_django_utils.cache import RequestCache
@@ -50,8 +52,6 @@ class DeploymentMonitoringMiddleware:
         .. custom_attribute_description: The django version in use (e.g. '2.2.24').
            Set by DeploymentMonitoringMiddleware.
         """
-        if not newrelic:  # pragma: no cover
-            return
         _set_custom_attribute('django_version', django.__version__)
 
     @staticmethod
@@ -63,8 +63,6 @@ class DeploymentMonitoringMiddleware:
         .. custom_attribute_description: The Python version in use (e.g. '3.8.10').
            Set by DeploymentMonitoringMiddleware.
         """
-        if not newrelic:  # pragma: no cover
-            return
         _set_custom_attribute('python_version', platform.python_version())
 
 
@@ -262,3 +260,140 @@ class MonitoringMemoryMiddleware(MiddlewareMixin):
         Returns whether this middleware is enabled.
         """
         return waffle.switch_is_active('edx_django_utils.monitoring.enable_memory_middleware')
+
+
+class CookieMonitoringMiddleware:
+    """
+    Middleware for monitoring the size and growth of all our cookies, to see if
+    we're running into browser limits.
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        # Monitor at request-time to skip any cookies that may be added during the request.
+        log_message = None
+        try:
+            log_message = self.get_log_message_and_monitor_cookies(request)
+        except BaseException:
+            log.exception("Unexpected error logging and monitoring cookies.")
+
+        response = self.get_response(request)
+
+        # Delay logging until response-time so that the user id can be included in the log message.
+        if log_message:
+            log.info(log_message)
+
+        return response
+
+    def get_log_message_and_monitor_cookies(self, request):
+        """
+        Add logging and custom attributes for monitoring cookie sizes.
+
+        Don't log contents of cookies because that might cause a security issue.
+        We just want to see if any cookies are growing out of control.
+
+        Useful NRQL Queries:
+
+            # Always available
+            SELECT * FROM Transaction WHERE cookies.header.size > 6000
+
+        Attributes that are added by this middleware:
+
+            For all requests:
+
+                cookies.header.size: The total size in bytes of the cookie header
+
+            If COOKIE_HEADER_SIZE_LOGGING_THRESHOLD is reached:
+
+                cookies.header.size.computed
+
+        Related Settings (see annotations for details):
+
+            - COOKIE_HEADER_SIZE_LOGGING_THRESHOLD
+            - COOKIE_SAMPLING_REQUEST_COUNT
+
+        Returns: The message to be logged. This is returned, rather than directly
+            logged, so that it can be processed at request time (before any cookies
+            may be changed server-side), but logged at response time, once the user
+            id is available for authenticated calls.
+
+        """
+        raw_header_cookie = request.META.get('HTTP_COOKIE', '')
+        cookie_header_size = len(raw_header_cookie.encode('utf-8'))
+        # .. custom_attribute_name: cookies.header.size
+        # .. custom_attribute_description: The total size in bytes of the cookie header.
+        _set_custom_attribute('cookies.header.size', cookie_header_size)
+
+        if cookie_header_size == 0:
+            return None
+
+        if corrupt_cookie_count := raw_header_cookie.count('Cookie: '):
+            # .. custom_attribute_name: cookies.header.corrupt_count
+            # .. custom_attribute_description: The attribute will only appear for potentially corrupt cookie headers,
+            #   where "Cookie: " is found in the header. If this custom attribute is seen on the same
+            #   requests where other mysterious cookie problems are occurring, this may help troubleshoot.
+            #   See https://openedx.atlassian.net/browse/CR-4614 for more details.
+            #   Also see cookies.header.corrupt_key_count
+            _set_custom_attribute('cookies.header.corrupt_count', corrupt_cookie_count)
+            # .. custom_attribute_name: cookies.header.corrupt_key_count
+            # .. custom_attribute_description: The attribute will only appear for potentially corrupt cookie headers,
+            #   where "Cookie: " is found in some of the cookie keys. If this custom attribute is seen on the same
+            #   requests where other mysterious cookie problems are occurring, this may help troubleshoot.
+            #   See https://openedx.atlassian.net/browse/CR-4614 for more details.
+            #   Also see cookies.header.corrupt_count.
+            _set_custom_attribute(
+                'cookies.header.corrupt_key_count',
+                sum(1 for key in request.COOKIES.keys() if 'Cookie: ' in key)
+            )
+
+        # .. setting_name: COOKIE_HEADER_SIZE_LOGGING_THRESHOLD
+        # .. setting_default: None
+        # .. setting_description: The minimum size for the full cookie header to log a list of cookie names and sizes.
+        #   Should be set to a relatively high threshold (suggested 9-10K) to avoid flooding the logs.
+        logging_threshold = getattr(settings, "COOKIE_HEADER_SIZE_LOGGING_THRESHOLD", None)
+
+        if not logging_threshold:
+            return None
+
+        is_large_cookie_header_detected = cookie_header_size >= logging_threshold
+        if not is_large_cookie_header_detected:
+            # .. setting_name: COOKIE_SAMPLING_REQUEST_COUNT
+            # .. setting_default: None
+            # .. setting_description: This setting enables sampling cookie header logging for cookie headers smaller
+            #   than COOKIE_HEADER_SIZE_LOGGING_THRESHOLD. The cookie header logging will happen randomly for each
+            #   request with a chance of 1 in COOKIE_SAMPLING_REQUEST_COUNT. For example, to see approximately one
+            #   sampled log message every 10 minutes, set COOKIE_SAMPLING_REQUEST_COUNT to the average number of
+            #   requests in 10 minutes.
+            # .. setting_warning: This setting requires COOKIE_HEADER_SIZE_LOGGING_THRESHOLD to be enabled to take
+            #   effect.
+            sampling_request_count = getattr(settings, "COOKIE_SAMPLING_REQUEST_COUNT", None)
+
+            # if the cookie header size is lower than the threshold, skip logging unless configured to do
+            #   random sampling and we choose the lucky number (in this case, 1).
+            if not sampling_request_count or random.randint(1, sampling_request_count) > 1:
+                return None
+
+        # The computed header size can be used to double check that there aren't large cookies that are
+        #   duplicates in the original header (from different domains) that aren't being accounted for.
+        cookies_header_size_computed = max(
+            0, sum(len(name) + len(value) + 3 for (name, value) in request.COOKIES.items()) - 2
+        )
+
+        # .. custom_attribute_name: cookies.header.size.computed
+        # .. custom_attribute_description: The computed total size in bytes of the cookie header, based on the
+        #   cookies found in request.COOKIES. This value will only be captured for cookie headers larger than
+        #   COOKIE_HEADER_SIZE_LOGGING_THRESHOLD. The value can be used to double check that there aren't large
+        #   cookies that are duplicates in the cookie header (from different domains) that aren't being accounted
+        #   for.
+        _set_custom_attribute('cookies.header.size.computed', cookies_header_size_computed)
+
+        # Sort starting with largest cookies
+        sorted_cookie_items = sorted(request.COOKIES.items(), key=lambda x: len(x[1]), reverse=True)
+        sizes = ', '.join(f"{name}: {len(value)}" for (name, value) in sorted_cookie_items)
+        if is_large_cookie_header_detected:
+            log_prefix = f"Large (>= {logging_threshold}) cookie header detected."
+        else:
+            log_prefix = f"Sampled small (< {logging_threshold}) cookie header."
+        log_message = f"{log_prefix} BEGIN-COOKIE-SIZES(total={cookie_header_size}) {sizes} END-COOKIE-SIZES"
+        return log_message

--- a/edx_django_utils/monitoring/scripts/process_cookie_monitoring_logs.py
+++ b/edx_django_utils/monitoring/scripts/process_cookie_monitoring_logs.py
@@ -1,0 +1,212 @@
+"""
+This script will process logs generated from CookieMonitoringMiddleware.
+
+Sample usage::
+
+    python edx_django_utils/monitoring/scripts/process_cookie_monitoring_logs.py --csv_input large-cookie-logs.csv
+
+Or for more details::
+
+    python edx_django_utils/monitoring/scripts/process_cookie_monitoring_logs.py --help
+
+"""
+import csv
+import logging
+import re
+
+import click
+from dateutil import parser
+
+logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.INFO)
+
+
+# Note: Not all Open edX deployments will be affected by the same third-party cookies,
+#   but it is ok to have some of these cookies go unused.
+PARAMETERIZED_COOKIES = [
+    (re.compile(r"_gac_UA-(\d|-)+"), "_gac_UA-{id}"),
+    (re.compile(r"_hjSession_\d+"), "_hjSession_{id}"),
+    (re.compile(r"_hjSessionUser_\d+"), "_hjSessionUser_{id}"),
+    (re.compile(r"ab\.storage\.deviceId\..*"), "ab.storage.deviceId.{id}"),
+    (re.compile(r"ab\.storage\.sessionId\..*"), "ab.storage.deviceId.{id}"),
+    (re.compile(r"ab\.storage\.userId\..*"), "ab.storage.userId.{id}"),
+    (re.compile(r"AMCV_\w+%40AdobeOrg"), "AMCV_{id}@AdobeOrg"),
+    (re.compile(r"amplitude_id_.*"), "amplitude_id_{id}"),
+    (re.compile(r"mp_\w+_mixpanel"), "mp_{id}_mixpanel"),
+]
+
+
+@click.command()
+@click.option(
+    "--csv_input",
+    help="File name of .csv file with Splunk logs for large cookie headers.",
+    required=True
+)
+def main(csv_input):
+    """
+    Reads CSV of large cookie logs and processes and provides summary output.
+
+    Expected CSV format (from Splunk export searching on "BEGIN-COOKIE-SIZES"):
+
+        \b
+        _raw,_time,index,
+        ...
+
+    """
+    cookie_headers = _load_csv(csv_input)
+    processed_cookie_headers = process_cookie_headers(cookie_headers)
+    print_processed_cookies(processed_cookie_headers)
+
+
+def _load_csv(csv_file):
+    """
+    Reads CSV of large cookie data and returns a dict of details.
+
+    Arguments:
+        csv_file (string): File name for the csv
+
+    Returns a list of dicts containing parsed details for each cookie header log entry.
+
+    """
+    with open(csv_file) as file:
+        csv_data = file.read()
+    reader = csv.DictReader(csv_data.splitlines())
+
+    # Regex to match against log messages like the following:
+    #   BEGIN-COOKIE-SIZES(total=3773) user-info: 903, csrftoken: 64, ... END-COOKIE-SIZES
+    cookie_log_regex = re.compile(r"BEGIN-COOKIE-SIZES\(total=(?P<total>\d+)\)(?P<cookie_sizes>.*)END-COOKIE-SIZES")
+    # Regex to match against just a single size, like the following:
+    #   csrftoken: 64
+    cookie_size_regex = re.compile(r"(?P<name>.*): (?P<size>\d+)")
+
+    cookie_headers = []
+    for row in reader:
+        cookie_header_sizes = {}
+
+        raw_cookie_log = row.get("_raw")
+        cookie_begin_count = raw_cookie_log.count("BEGIN-COOKIE-SIZES")
+        if cookie_begin_count == 0:
+            logging.info("No BEGIN-COOKIE-SIZES delimiter found. Skipping row.")
+        elif cookie_begin_count > 1:
+            # Note: this wouldn't parse correctly right now, and it isn't worth coding for.
+            logging.warning("Multiple cookie entries found in same row. Skipping row.")
+            continue
+        match = cookie_log_regex.search(raw_cookie_log)
+        if not match:
+            logging.error("Malformed cookie entry. Skipping row.")
+            continue
+
+        cookie_header_size = int(match.group("total"))
+        if cookie_header_size == 0:
+            continue
+
+        cookie_sizes_str = match.group("cookie_sizes").strip()
+
+        cookie_sizes = cookie_sizes_str.split(", ")
+        for cookie_size in cookie_sizes:
+            match = cookie_size_regex.search(cookie_size)
+            if not match:
+                logging.error(f"Could not parse cookie size from: {cookie_size}")
+                continue
+            cookie_header_sizes[match.group("name")] = int(match.group("size"))
+
+        cookie_header_size_computed = max(
+            0, sum(len(name) + size + 3 for (name, size) in cookie_header_sizes.items()) - 2
+        )
+
+        cookie_headers.append({
+            "datetime": parser.parse(row.get("_time")),
+            "env": row.get("index"),
+            "cookie_header_size": cookie_header_size,
+            "cookie_header_size_computed": cookie_header_size_computed,
+            "cookie_sizes": cookie_header_sizes,
+        })
+
+    return cookie_headers
+
+
+def process_cookie_headers(cookie_headers):
+    """
+    Process the parsed cookie header log entries.
+
+    Arguments:
+        cookie_headers: a list of dicts containing parsed details.
+
+    Returns a dict of processed cookies.
+    """
+    processed_cookies = {}
+    for cookie_header in cookie_headers:
+        for (name, size) in cookie_header["cookie_sizes"].items():
+
+            # Replace parameterized cookies. For example:
+            #   _hjSessionUser_111111 => _hjSessionUser_{id}
+            for (regex, replacement_name) in PARAMETERIZED_COOKIES:
+                if regex.fullmatch(name):
+                    logging.debug(f"Replacing {name} with {replacement_name}.")
+                    name = replacement_name
+                    break
+
+            processed_cookie = processed_cookies.get(name, {})
+
+            # compute the full size each cookie takes up in the cookie header, including name and delimiters
+            full_size = len(name) + size + 3
+            set_max_attribute(processed_cookie, "max_full_size", full_size)
+            set_min_attribute(processed_cookie, "min_full_size", full_size)
+
+            set_max_attribute(processed_cookie, "max_size", size)
+            set_min_attribute(processed_cookie, "min_size", size)
+
+            processed_cookie["count"] = processed_cookie.get("count", 0) + 1
+
+            # Note: The following details relate to the header, and not to the specific cookie.
+            #   This may give a quick view of cookies associated with the largest header, or the
+            #   header with the most cookies.
+
+            set_max_attribute(processed_cookie, "last_seen", cookie_header["datetime"])
+            set_min_attribute(processed_cookie, "first_seen", cookie_header["datetime"])
+
+            set_max_attribute(processed_cookie, "max_cookie_count", len(cookie_header["cookie_sizes"]))
+            set_min_attribute(processed_cookie, "min_cookie_count", len(cookie_header["cookie_sizes"]))
+            set_max_attribute(processed_cookie, "max_header_size", cookie_header["cookie_header_size"])
+            set_min_attribute(processed_cookie, "min_header_size", cookie_header["cookie_header_size"])
+            # Note: skipping cookie_header_size_calculated unless we see a need for it.
+
+            processed_cookie["envs"] = processed_cookie.get("envs", set())
+            processed_cookie["envs"].add(cookie_header["env"])
+
+            processed_cookies[name] = processed_cookie
+
+    return processed_cookies
+
+
+def set_min_attribute(processed_cookie, key, value):
+    """
+    Sets processed_cookie[key] to the smaller of value and its current value.
+    """
+    processed_cookie[key] = min(value, processed_cookie.get(key, value))
+
+
+def set_max_attribute(processed_cookie, key, value):
+    """
+    Sets processed_cookie[key] to the larger of value and its current value.
+    """
+    processed_cookie[key] = max(value, processed_cookie.get(key, value))
+
+
+def print_processed_cookies(processed_cookies):
+    """
+    Output processed cookie information.
+    """
+    sorted_cookie_items = sorted(processed_cookies.items(), key=lambda x: x[1]["max_full_size"], reverse=True)
+    print("name,max_full_size,min_full_size,max_size,min_size,count,"
+          "last_seen,first_seen,max_cookie_count,min_cookie_count,max_header_size,min_header_size,envs")
+    for (name, data) in sorted_cookie_items:
+        print(f'{name},{data["max_full_size"]},{data["min_full_size"]},'
+              f'{data["max_size"]},{data["min_size"]},{data["count"]},'
+              f'{data["last_seen"]},{data["first_seen"]},'
+              f'{data["max_cookie_count"]},{data["min_cookie_count"]},'
+              f'{data["max_header_size"]},{data["min_header_size"]},'
+              f'"{",".join(sorted(data["envs"]))}"')
+
+
+if __name__ == "__main__":
+    main()  # pylint: disable=no-value-for-parameter

--- a/edx_django_utils/monitoring/tests/test_middleware.py
+++ b/edx_django_utils/monitoring/tests/test_middleware.py
@@ -1,15 +1,23 @@
 """
 Tests monitoring middleware.
 
-Note: CachedCustomMonitoringMiddleware is tested in ``test_monitoring.py``.
+Note: CachedCustomMonitoringMiddleware is tested in ``test_custom_monitoring.py``.
 """
-from unittest.mock import patch
+import re
+from unittest.mock import Mock, call, patch
 
+import ddt
 from django.test import TestCase
 from django.test.client import RequestFactory
+from django.test.utils import override_settings
 from waffle.testutils import override_switch
 
-from edx_django_utils.monitoring import MonitoringMemoryMiddleware
+from edx_django_utils.cache import RequestCache
+from edx_django_utils.monitoring import (
+    CookieMonitoringMiddleware,
+    DeploymentMonitoringMiddleware,
+    MonitoringMemoryMiddleware
+)
 
 
 class TestMonitoringMemoryMiddleware(TestCase):
@@ -34,3 +42,168 @@ class TestMonitoringMemoryMiddleware(TestCase):
             'fake response',
         )
         mock_logger.info.assert_called()
+
+
+class TestDeploymentMonitoringMiddleware(TestCase):
+    """
+    Test the DeploymentMonitoringMiddleware functionalities
+    """
+    version_pattern = r'\d+(\.\d+){2}'
+
+    def setUp(self):
+        super().setUp()
+        RequestCache.clear_all_namespaces()
+
+    def _test_key_value_pair(self, function_call, key):
+        """
+        Asserts the function call key and value with the provided key and the default version_pattern
+        """
+        attribute_key, attribute_value = function_call[0]
+        assert attribute_key == key
+        assert re.match(re.compile(self.version_pattern), attribute_value)
+
+    @patch('newrelic.agent')
+    def test_record_python_and_django_version(self, mock_newrelic_agent):
+        """
+        Test that the DeploymentMonitoringMiddleware records the correct Python and Django versions
+        """
+        middleware = DeploymentMonitoringMiddleware(Mock())
+        middleware(Mock())
+
+        parameter_calls_count = mock_newrelic_agent.add_custom_parameter.call_count
+        assert parameter_calls_count == 2
+
+        function_calls = mock_newrelic_agent.add_custom_parameter.call_args_list
+        self._test_key_value_pair(function_calls[0], 'python_version')
+        self._test_key_value_pair(function_calls[1], 'django_version')
+
+
+@ddt.ddt
+class CookieMonitoringMiddlewareTestCase(TestCase):
+    """
+    Tests for CookieMonitoringMiddleware.
+    """
+    def setUp(self):
+        super().setUp()
+        self.mock_response = Mock()
+
+    @patch('edx_django_utils.monitoring.internal.middleware.log', autospec=True)
+    @patch("edx_django_utils.monitoring.internal.middleware._set_custom_attribute")
+    @ddt.data(
+        (None, None),  # logging threshold not defined
+        (5, None),  # logging threshold too high
+        (5, 9999999999999999999),  # logging threshold too high, and random sampling impossibly unlikely
+    )
+    @ddt.unpack
+    def test_cookie_monitoring_with_no_logging(
+        self, logging_threshold, sampling_request_count, mock_set_custom_attribute, mock_logger
+    ):
+        expected_response = self.mock_response
+        middleware = CookieMonitoringMiddleware(lambda request: expected_response)
+        cookies_dict = {'a': 'y'}
+
+        with override_settings(COOKIE_HEADER_SIZE_LOGGING_THRESHOLD=logging_threshold):
+            with override_settings(COOKIE_SAMPLING_REQUEST_COUNT=sampling_request_count):
+                actual_response = middleware(self.get_mock_request(cookies_dict))
+
+        assert actual_response == expected_response
+        # expect monitoring of header size for all requests
+        mock_set_custom_attribute.assert_called_once_with('cookies.header.size', 3)
+        # cookie logging was not enabled, so nothing should be logged
+        mock_logger.info.assert_not_called()
+        mock_logger.exception.assert_not_called()
+
+    @override_settings(COOKIE_HEADER_SIZE_LOGGING_THRESHOLD=None)
+    @override_settings(COOKIE_SAMPLING_REQUEST_COUNT=None)
+    @patch("edx_django_utils.monitoring.internal.middleware._set_custom_attribute")
+    @ddt.data(
+        # A corrupt cookie header contains "Cookie: ".
+        ('corruptCookie: normal-cookie=value', 1, 1),
+        ('corrupt1Cookie: normal-cookie1=value1;corrupt2Cookie: normal-cookie2=value2', 2, 2),
+        ('corrupt=Cookie: value', 1, 0),
+    )
+    @ddt.unpack
+    def test_cookie_header_corrupt_monitoring(
+        self, corrupt_cookie_header, expected_corrupt_count, expected_corrupt_key_count, mock_set_custom_attribute
+    ):
+        middleware = CookieMonitoringMiddleware(self.mock_response)
+        request = RequestFactory().request()
+        request.META['HTTP_COOKIE'] = corrupt_cookie_header
+
+        middleware(request)
+
+        mock_set_custom_attribute.assert_has_calls([
+            call('cookies.header.size', len(request.META['HTTP_COOKIE'])),
+            call('cookies.header.corrupt_count', expected_corrupt_count),
+            call('cookies.header.corrupt_key_count', expected_corrupt_key_count),
+        ])
+
+    @override_settings(COOKIE_HEADER_SIZE_LOGGING_THRESHOLD=1)
+    @patch('edx_django_utils.monitoring.internal.middleware.log', autospec=True)
+    @patch("edx_django_utils.monitoring.internal.middleware._set_custom_attribute")
+    def test_log_cookie_with_threshold_met(self, mock_set_custom_attribute, mock_logger):
+        middleware = CookieMonitoringMiddleware(self.mock_response)
+        cookies_dict = {
+            "a": "yy",
+            "b": "xxx",
+            "c": "z",
+        }
+
+        middleware(self.get_mock_request(cookies_dict))
+
+        mock_set_custom_attribute.assert_has_calls([
+            call('cookies.header.size', 16),
+            call('cookies.header.size.computed', 16)
+        ])
+        mock_logger.info.assert_called_once_with(
+            "Large (>= 1) cookie header detected. BEGIN-COOKIE-SIZES(total=16) b: 3, a: 2, c: 1 END-COOKIE-SIZES"
+        )
+        mock_logger.exception.assert_not_called()
+
+    @override_settings(COOKIE_HEADER_SIZE_LOGGING_THRESHOLD=9999)
+    @override_settings(COOKIE_SAMPLING_REQUEST_COUNT=1)
+    @patch('edx_django_utils.monitoring.internal.middleware.log', autospec=True)
+    @patch("edx_django_utils.monitoring.internal.middleware._set_custom_attribute")
+    def test_log_cookie_with_sampling(self, mock_set_custom_attribute, mock_logger):
+        middleware = CookieMonitoringMiddleware(self.mock_response)
+        cookies_dict = {
+            "a": "yy",
+            "b": "xxx",
+            "c": "z",
+        }
+
+        middleware(self.get_mock_request(cookies_dict))
+
+        mock_set_custom_attribute.assert_has_calls([
+            call('cookies.header.size', 16),
+            call('cookies.header.size.computed', 16)
+        ])
+        mock_logger.info.assert_called_once_with(
+            "Sampled small (< 9999) cookie header. BEGIN-COOKIE-SIZES(total=16) b: 3, a: 2, c: 1 END-COOKIE-SIZES"
+        )
+        mock_logger.exception.assert_not_called()
+
+    @override_settings(COOKIE_HEADER_SIZE_LOGGING_THRESHOLD=9999)
+    @override_settings(COOKIE_SAMPLING_REQUEST_COUNT=1)
+    @patch('edx_django_utils.monitoring.internal.middleware.log', autospec=True)
+    @patch("edx_django_utils.monitoring.internal.middleware._set_custom_attribute")
+    def test_empty_cookie_header_skips_sampling(self, mock_set_custom_attribute, mock_logger):
+        middleware = CookieMonitoringMiddleware(self.mock_response)
+        cookies_dict = {}
+
+        middleware(self.get_mock_request(cookies_dict))
+
+        mock_set_custom_attribute.assert_has_calls([
+            call('cookies.header.size', 0),
+        ])
+        mock_logger.info.assert_not_called()
+        mock_logger.exception.assert_not_called()
+
+    def get_mock_request(self, cookies_dict):
+        """
+        Return mock request with the provided cookies in the header.
+        """
+        factory = RequestFactory()
+        for name, value in cookies_dict.items():
+            factory.cookies[name] = value
+        return factory.request()

--- a/edx_django_utils/monitoring/tests/test_middleware.py
+++ b/edx_django_utils/monitoring/tests/test_middleware.py
@@ -199,6 +199,18 @@ class CookieMonitoringMiddlewareTestCase(TestCase):
         mock_logger.info.assert_not_called()
         mock_logger.exception.assert_not_called()
 
+    @patch('edx_django_utils.monitoring.internal.middleware.log', autospec=True)
+    def test_cookie_monitoring_unknown_exception(self, mock_logger):
+        middleware = CookieMonitoringMiddleware(self.mock_response)
+        cookies_dict = {'a': 'y'}
+        mock_request = self.get_mock_request(cookies_dict)
+        mock_request.META = Mock()
+        mock_request.META.side_effect = Exception("Some exception")
+
+        middleware(mock_request)
+
+        mock_logger.exception.assert_called_once_with("Unexpected error logging and monitoring cookies.")
+
     def get_mock_request(self, cookies_dict):
         """
         Return mock request with the provided cookies in the header.

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -46,7 +46,7 @@ tox==3.24.5
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-urllib3==1.26.8
+urllib3==1.26.9
     # via requests
 virtualenv==20.13.3
     # via tox

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -7,3 +7,4 @@
 
 diff-cover                # Changeset diff test coverage
 edx-i18n-tools            # For i18n_tool dummy
+python-dateutil           # Date utility for local script

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -106,7 +106,7 @@ lazy-object-proxy==1.7.1
     # via
     #   -r requirements/quality.txt
     #   astroid
-markupsafe==2.1.0
+markupsafe==2.1.1
     # via
     #   -r requirements/quality.txt
     #   jinja2
@@ -201,6 +201,8 @@ pytest-cov==3.0.0
     # via -r requirements/quality.txt
 pytest-django==4.5.2
     # via -r requirements/quality.txt
+python-dateutil==2.8.2
+    # via -r requirements/dev.in
 python-slugify==6.1.1
     # via
     #   -r requirements/quality.txt
@@ -223,6 +225,7 @@ six==1.16.0
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   edx-lint
+    #   python-dateutil
     #   tox
     #   virtualenv
 snowballstemmer==2.2.0
@@ -265,7 +268,7 @@ typing-extensions==4.1.1
     #   -r requirements/quality.txt
     #   astroid
     #   pylint
-urllib3==1.26.8
+urllib3==1.26.9
     # via
     #   -r requirements/ci.txt
     #   requests

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -30,7 +30,7 @@ coverage[toml]==6.3.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==36.0.1
+cryptography==36.0.2
     # via secretstorage
 ddt==1.4.4
     # via -r requirements/test.txt
@@ -73,7 +73,7 @@ jinja2==3.0.3
     # via sphinx
 keyring==23.5.0
     # via twine
-markupsafe==2.1.0
+markupsafe==2.1.1
     # via jinja2
 mock==4.0.3
     # via -r requirements/test.txt
@@ -183,7 +183,7 @@ tqdm==4.63.0
     # via twine
 twine==3.8.0
     # via -r requirements/doc.in
-urllib3==1.26.8
+urllib3==1.26.9
     # via
     #   requests
     #   twine

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -54,7 +54,7 @@ jinja2==3.0.3
     # via code-annotations
 lazy-object-proxy==1.7.1
     # via astroid
-markupsafe==2.1.0
+markupsafe==2.1.1
     # via jinja2
 mccabe==0.6.1
     # via pylint


### PR DESCRIPTION
**Description:**

Adds CookieMonitoringMiddleware for monitoring cookie header sizes
and cookie sizes. This middleware is being moved from edx-platform:
https://github.com/openedx/edx-platform/blob/master/openedx/core/lib/request_utils.py#L93

Also includes moving the process_cookie_monitoring_logs.py
script to this repository.

**JIRA:**

[ARCHBOM-2054](https://openedx.atlassian.net/browse/ARCHBOM-2054)

**Dependencies:**

List dependencies on other outstanding PRs, issues, etc.

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**

I attempted a consolidated MonitoringMiddleware, but it got messy fast, and would have required a bunch of engineering to keep clean. So for now, we just need to add additional middleware as-needed.