### PR TITLE
feat: Improvements to corrupt cookie logging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,17 @@ Change Log
 Unreleased
 ----------
 
+[4.9.0] - 2022-05-19
+--------------------
+
+Changed
+~~~~~~~
+
+* Corrupt cookie logging:
+
+  * Now independent of other cookie logging; no longer needs to meet cookie size threshold or sampling rate.
+  * New setting ``UNUSUAL_COOKIE_SAMPLING_LOG_CHUNK`` helps avoid truncated (non-decryptable) messages by splitting the output across multiple log messages.
+
 [4.8.1] - 2022-05-06
 --------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,7 @@ Changed
 * Corrupt cookie logging:
 
   * Now independent of other cookie logging; no longer needs to meet cookie size threshold or sampling rate.
-  * New setting ``UNUSUAL_COOKIE_SAMPLING_LOG_CHUNK`` helps avoid truncated (non-decryptable) messages by splitting the output across multiple log messages.
+  * New setting ``UNUSUAL_COOKIE_HEADER_LOG_CHUNK`` helps avoid truncated (non-decryptable) messages by splitting the output across multiple log messages.
 
 [4.8.1] - 2022-05-06
 --------------------

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,7 +2,7 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "4.8.1"
+__version__ = "4.9.0"
 
 default_app_config = (
     "edx_django_utils.apps.EdxDjangoUtilsConfig"

--- a/edx_django_utils/monitoring/internal/middleware.py
+++ b/edx_django_utils/monitoring/internal/middleware.py
@@ -455,6 +455,18 @@ class CookieMonitoringMiddleware:
             log.info(piece)
 
 
+# This function should be cleaned up and made into a general logging utility, but it will first
+# need some work to make it able to handle multibyte characters.
+#
+# - If you split on character count, then you may exceed the line size if there are a large number
+#   of multibyte characters.
+# - If you split on byte count, then multibyte characters like "犬" run a risk of being split
+#   between the bytes, resulting in b'ç' and 'b\x8a¬' and no easy way to reconstruct the data.
+#
+# It may be that there's some library that already does this. In the meantime, this code should be
+# sufficient for corrupted cookie logging, with its known-character-range code.
+#
+# If it is separated out, it should get its own setting, maybe `LONG_LOG_MESSAGE_CHUNK_SIZE`.
 def split_ascii_log_message(msg, chunk_size):
     """
     Generator that splits a message string into chunks of at most ``chunk_size`` characters.

--- a/edx_django_utils/monitoring/internal/middleware.py
+++ b/edx_django_utils/monitoring/internal/middleware.py
@@ -441,8 +441,10 @@ class CookieMonitoringMiddleware:
         # .. setting_default: 9000
         # .. setting_description: If necessary, logs data in chunks of this size, splitting across
         #   multiple log messages. This should be set with your deployment's maximum log message
-        #   size in mind: Setting it too high may result in truncated messages, which will prevent
-        #   decryption (CryptoError).
+        #   size in mind. Setting it too high may result in truncated messages, which will prevent
+        #   decryption (CryptoError). Since there is a relatively constant-size prefix on all log
+        #   messages (date, module, etc.) this chunk size should be at least 500 bytes shorter than
+        #   the max log message size to provide a reasonable margin of safety.
         chunk_size = getattr(settings, 'UNUSUAL_COOKIE_HEADER_LOG_CHUNK', 9000)
 
         header_data = json.dumps(dict(request.headers.items()))
@@ -462,7 +464,7 @@ def split_ascii_log_message(msg, chunk_size):
 
     A small collation tag will be added to the end of each chunk, and it may not be possible
     to reliably predict the length of a log message's prefix (in its final output format), so
-    the ``chunk_size`` should be set conservatively.
+    the ``chunk_size`` should be set considerably smaller than max log message size.
     """
     chunk_count = math.ceil(len(msg) / chunk_size)
     if chunk_count <= 1:

--- a/edx_django_utils/monitoring/tests/test_middleware.py
+++ b/edx_django_utils/monitoring/tests/test_middleware.py
@@ -180,12 +180,54 @@ class CookieMonitoringMiddlewareTestCase(TestCase):
             "some private key",
         )
 
-        # Encrypted headers are appended, along with corrupt cookie count, if any appeared corrupted
-        mock_logger.info.assert_called_once_with(
-            "Large (>= 1) cookie header detected. "
-            "BEGIN-COOKIE-SIZES(total=37) ccc: 11, bCookie: bb: 2, aa: 1 END-COOKIE-SIZES "
-            "All headers, with 2 likely corruptions: [encrypted: 50M3JUN|<]"
+        # Encrypted headers are logged in additional message if any cookies appeared corrupted.
+        mock_logger.info.assert_has_calls([
+            call("All headers for request with corrupted cookies (count=2): [encrypted: 50M3JUN|<]"),
+            call(
+                "Large (>= 1) cookie header detected. "
+                "BEGIN-COOKIE-SIZES(total=37) ccc: 11, bCookie: bb: 2, aa: 1 END-COOKIE-SIZES"
+            ),
+        ])
+
+    @override_settings(
+        COOKIE_HEADER_SIZE_LOGGING_THRESHOLD=1,
+        UNUSUAL_COOKIE_SAMPLING_PUBLIC_KEY="some private key",
+        UNUSUAL_COOKIE_SAMPLING_LOG_CHUNK=75,
+    )
+    @patch('edx_django_utils.monitoring.internal.middleware.log', autospec=True)
+    @patch(
+        "edx_django_utils.monitoring.internal.middleware.encrypt_for_log",
+        return_value="[encrypted: 50M3JUN|<_aaaabbbbccccdddd]"
+    )
+    def test_log_corrupt_cookies_split(self, mock_encrypt, mock_logger):
+        """
+        Like ``test_log_corrupt_cookies`` but with message splitting.
+        """
+        middleware = CookieMonitoringMiddleware(self.mock_response)
+        request = RequestFactory().request()
+        request.META['HTTP_COOKIE'] = 'aa=1; bCookie: bb=22; ccc=3Cookie: 33'
+        request.META['HTTP_SOMETHING'] = 'else'
+
+        middleware(request)
+
+        # Is passed all headers
+        mock_encrypt.assert_called_once_with(
+            '{"Cookie": "aa=1; bCookie: bb=22; ccc=3Cookie: 33", "Something": "else"}',
+            "some private key",
         )
+
+        # Encrypted headers are logged across multiple messages if too large.
+        mock_logger.info.assert_has_calls([
+            call(
+                "All headers for request with corrupted cookies (count=2): "
+                "[encrypted: 50M3J [chunk #1, group=OUMTkx5O continues]"
+            ),
+            call("UN|<_aaaabbbbccccdddd] [chunk #2, group=OUMTkx5O final]"),
+            call(
+                "Large (>= 1) cookie header detected. "
+                "BEGIN-COOKIE-SIZES(total=37) ccc: 11, bCookie: bb: 2, aa: 1 END-COOKIE-SIZES"
+            ),
+        ])
 
     @override_settings(COOKIE_HEADER_SIZE_LOGGING_THRESHOLD=9999)
     @override_settings(COOKIE_SAMPLING_REQUEST_COUNT=1)

--- a/edx_django_utils/monitoring/tests/test_middleware.py
+++ b/edx_django_utils/monitoring/tests/test_middleware.py
@@ -162,7 +162,7 @@ class CookieMonitoringMiddlewareTestCase(TestCase):
 
     @override_settings(
         COOKIE_HEADER_SIZE_LOGGING_THRESHOLD=1,
-        UNUSUAL_COOKIE_SAMPLING_PUBLIC_KEY="some private key",
+        UNUSUAL_COOKIE_HEADER_PUBLIC_KEY="some private key",
     )
     @patch('edx_django_utils.monitoring.internal.middleware.log', autospec=True)
     @patch("edx_django_utils.monitoring.internal.middleware.encrypt_for_log", return_value="[encrypted: 50M3JUN|<]")
@@ -191,8 +191,8 @@ class CookieMonitoringMiddlewareTestCase(TestCase):
 
     @override_settings(
         COOKIE_HEADER_SIZE_LOGGING_THRESHOLD=1,
-        UNUSUAL_COOKIE_SAMPLING_PUBLIC_KEY="some private key",
-        UNUSUAL_COOKIE_SAMPLING_LOG_CHUNK=75,
+        UNUSUAL_COOKIE_HEADER_PUBLIC_KEY="some private key",
+        UNUSUAL_COOKIE_HEADER_LOG_CHUNK=75,
     )
     @patch('edx_django_utils.monitoring.internal.middleware.log', autospec=True)
     @patch(


### PR DESCRIPTION
**Description:**

- Make independent of other cookie logging; no longer needs to meet cookie
  size threshold or sampling rate.
- New setting `UNUSUAL_COOKIE_SAMPLING_LOG_CHUNK` helps avoid truncated
  (non-decryptable) messages by splitting the output across multiple log
  messages.

**JIRA:**

ref: 2U ARCHBOM-2082

**Merge checklist:**
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**

List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
