### PR TITLE
docs: fix link to 'how to enable plugins'

### DIFF
--- a/edx_django_utils/plugins/README.rst
+++ b/edx_django_utils/plugins/README.rst
@@ -62,7 +62,7 @@ Enable Plugins in an IDA
 
 `Instructions to enable plugins for an IDA`_
 
-.. _Instructions to Enable plugins in your ida: https://github.com/edx/edx-django-utils/blob/master/docs/how_tos/how_to_enable_plugins_for_an_ida.rst
+.. _Instructions to enable plugins for an IDA: https://github.com/openedx/edx-django-utils/blob/master/edx_django_utils/plugins/docs/how_tos/how_to_enable_plugins_for_an_ida.rst
 
 
 Plugin Apps


### PR DESCRIPTION
**Description:**

This is just a minor fix for docs. Fixing incorrect rst sytanx along with adding the correct redirect link

**Reviewers:**
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Documentation updated (not only docstrings)