### PR TITLE
docs: remove doc publish todo from readme 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,9 +39,7 @@ This repository includes shared utilities for:
 Documentation
 -------------
 
-The full documentation is in the docs directory.
-
-TODO: Publish to https://edx-django-utils.readthedocs.org.
+The full documentation is in the docs directory, and is published to https://edx-django-utils.readthedocs.org.
 
 Development Workflow
 --------------------


### PR DESCRIPTION
**Description:**

The README still lists publishing docs as a TODO,
even though it has already been published.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [X] Documentation updated (not only docstrings)
- [ ] Commits are squashed