### PR TITLE
feat: Add wrapper for New Relic's background_task.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 ----------
 
+[5.2.0] - 2022-10-06
+--------------------
+
+Added
+~~~~~
+
+* Added a wrapper for background_task in monitoring.
+
 [5.1.0] - 2022-09-19
 --------------------
 

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,7 +2,7 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "5.1.0"
+__version__ = "5.2.0"
 
 default_app_config = (
     "edx_django_utils.apps.EdxDjangoUtilsConfig"

--- a/edx_django_utils/monitoring/__init__.py
+++ b/edx_django_utils/monitoring/__init__.py
@@ -23,6 +23,7 @@ from .internal.transactions import (
 )
 from .internal.utils import (
     accumulate,
+    background_task,
     increment,
     record_exception,
     set_custom_attribute,

--- a/edx_django_utils/monitoring/internal/utils.py
+++ b/edx_django_utils/monitoring/internal/utils.py
@@ -96,3 +96,21 @@ def record_exception():
     """
     if newrelic:  # pragma: no cover
         newrelic.agent.record_exception()
+
+
+def background_task(*args, **kwargs):
+    """
+    Handles monitoring for background tasks that are not passed in through the web server like
+    celery and event consuming tasks.
+
+    For more details, see:
+    https://docs.newrelic.com/docs/apm/agents/python-agent/supported-features/monitor-non-web-scripts-worker-processes-tasks-functions
+
+    """
+    def noop_decorator(func):
+        return func
+
+    if newrelic:  # pragma: no cover
+        return newrelic.agent.background_task(*args, **kwargs)
+    else:
+        return noop_decorator

--- a/edx_django_utils/monitoring/tests/test_utils.py
+++ b/edx_django_utils/monitoring/tests/test_utils.py
@@ -1,0 +1,25 @@
+"""
+Tests for utilities in monitoring.
+"""
+
+from unittest.mock import patch
+
+from edx_django_utils.monitoring import background_task
+
+
+@patch('edx_django_utils.monitoring.internal.utils.newrelic')
+def test_background_task_wrapper(wrapped_nr):
+    # We are verifying that this returns the correct decorated function
+    # in the two cases we care about.
+    returned_func = background_task()
+
+    assert returned_func == wrapped_nr.agent.background_task()
+
+
+@patch('edx_django_utils.monitoring.internal.utils.newrelic', None)
+def test_background_task_wrapper_no_new_relic():
+    # Test that the decorator behaves as a no-op when newrelic is not set.
+    returned_func = background_task()
+    wrapped_value = returned_func('a')
+
+    assert wrapped_value == 'a'


### PR DESCRIPTION
We would like to be able to add our own custom handling to background task monitoring, so we added a simple wrapper around it.