### PR TITLE
fix: add logging of both emails

### DIFF
--- a/edx_django_utils/user/management/commands/manage_user.py
+++ b/edx_django_utils/user/management/commands/manage_user.py
@@ -70,8 +70,8 @@ class Command(BaseCommand):
             raise CommandError(
                 _(
                     'Skipping user "{}" because the specified and existing email '
-                    'addresses do not match.'
-                ).format(user.username)
+                    'addresses "{}" and "{}" do not match.'
+                ).format(user.username, user.email, email)
             )
 
     def _handle_remove(self, username, email):

--- a/edx_django_utils/user/management/tests/test_manage_user.py
+++ b/edx_django_utils/user/management/tests/test_manage_user.py
@@ -117,7 +117,7 @@ class TestManageUserCommand(TestCase):
         # check that removal uses the same check
         with pytest.raises(CommandError) as exc_context:
             call_command('manage_user', TEST_USERNAME, 'other@example.com', '--remove')
-        assert "do not match' in str(exc_context.value).lower()
+        assert 'do not match' in str(exc_context.value).lower()
         assert [(TEST_USERNAME, TEST_EMAIL)] == [(u.username, u.email) for u in User.objects.all()]
 
     def test_same_email_varied_case(self):

--- a/edx_django_utils/user/management/tests/test_manage_user.py
+++ b/edx_django_utils/user/management/tests/test_manage_user.py
@@ -111,13 +111,13 @@ class TestManageUserCommand(TestCase):
         User.objects.create(username=TEST_USERNAME, email=TEST_EMAIL)
         with pytest.raises(CommandError) as exc_context:
             call_command('manage_user', TEST_USERNAME, 'other@example.com')
-        assert 'email addresses do not match' in str(exc_context.value).lower()
+        assert 'do not match' in str(exc_context.value).lower()
         assert [(TEST_USERNAME, TEST_EMAIL)] == [(u.username, u.email) for u in User.objects.all()]
 
         # check that removal uses the same check
         with pytest.raises(CommandError) as exc_context:
             call_command('manage_user', TEST_USERNAME, 'other@example.com', '--remove')
-        assert 'email addresses do not match' in str(exc_context.value).lower()
+        assert "do not match' in str(exc_context.value).lower()
         assert [(TEST_USERNAME, TEST_EMAIL)] == [(u.username, u.email) for u in User.objects.all()]
 
     def test_same_email_varied_case(self):


### PR DESCRIPTION
JIRA:PSRE-2274

**Description:**

I wanted to see the other email address - not the one logged as email in the yaml file - so this ticket adds a tiny bit of logging to do that. 

**JIRA:**

[PSRE-2274](https://openedx.atlassian.net/browse/PSRE-2274)

**Dependencies:**

List dependencies on other outstanding PRs, issues, etc.

**Merge deadline:**

List merge deadline (if any)

**Installation instructions:**

List any non-trivial installation
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**

List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
