### PR TITLE
chore: bump init version for release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Run coverage
       if: matrix.python-version == '3.8' && matrix.toxenv == 'django32'
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         flags: unittests
         fail_ci_if_error: true

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,7 +2,7 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "5.2.0"
+__version__ = "5.3.0"
 
 default_app_config = (
     "edx_django_utils.apps.EdxDjangoUtilsConfig"


### PR DESCRIPTION
JIRA:PSRE-2274

**Description:**

This bumps the release version to apply the changes in https://github.com/openedx/edx-django-utils/pull/280

**JIRA:**

[XXX-XXXX](https://openedx.atlassian.net/browse/XXX-XXXX)

**Dependencies:**

List dependencies on other outstanding PRs, issues, etc.

**Merge deadline:**

List merge deadline (if any)

**Installation instructions:**

List any non-trivial installation
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**

List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
