### PR TITLE
fix: include plugin docs in index

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,6 +45,25 @@ EdX utilities for Django Application development.
    monitoring/how_tos/search_new_relic_nrql
    monitoring/how_tos/update_monitoring_for_squad_or_theme_changes
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Plugins README
+
+   plugins/readme
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Plugins Decisions
+
+   plugins/decisions/0001-plugin-contexts
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Plugins How-Tos
+
+   plugins/how_tos/how_to_enable_plugins_for_an_ida
+
+
 Indices and tables
 ==================
 

--- a/docs/plugins/decisions/0001-plugin-contexts.rst
+++ b/docs/plugins/decisions/0001-plugin-contexts.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../edx_django_utils/plugins/docs/decisions/0001-plugin-contexts.rst

--- a/docs/plugins/how_tos/how_to_enable_plugins_for_an_ida.rst
+++ b/docs/plugins/how_tos/how_to_enable_plugins_for_an_ida.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../edx_django_utils/plugins/docs/how_tos/how_to_enable_plugins_for_an_ida.rst

--- a/docs/plugins/readme.rst
+++ b/docs/plugins/readme.rst
@@ -1,0 +1,1 @@
+.. include:: ../../edx_django_utils/plugins/README.rst


### PR DESCRIPTION
**Description:**

Adds the plugins docs to the main index. This will make fixing the links in https://github.com/openedx/edx-django-utils/pull/278 easier. It follows the same pattern as was used in the monitoring docs. It's a bit clunky but it does work. See the docs/maintenance README for why this approach was chosen.
