### PR TITLE
fix: update pip-tools to latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,5 +40,6 @@ jobs:
       if: matrix.python-version == '3.8' && matrix.toxenv == 'django32'
       uses: codecov/codecov-action@v3
       with:
+        files: htmlcov/index.html
         flags: unittests
         fail_ci_if_error: true

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-asgiref==3.5.2
+asgiref==3.6.0
     # via django
 cffi==1.15.1
     # via pynacl
 click==8.1.3
     # via -r requirements/base.in
-django==3.2.16
+django==3.2.18
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -19,19 +19,19 @@ django-crum==0.7.9
     # via -r requirements/base.in
 django-waffle==3.0.0
     # via -r requirements/base.in
-newrelic==8.5.0
+newrelic==8.8.0
     # via -r requirements/base.in
-pbr==5.11.0
+pbr==5.11.1
     # via stevedore
-psutil==5.9.4
+psutil==5.9.5
     # via -r requirements/base.in
 pycparser==2.21
     # via cffi
 pynacl==1.5.0
     # via -r requirements/base.in
-pytz==2022.6
+pytz==2023.3
     # via django
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via django
-stevedore==4.1.1
+stevedore==5.0.0
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,13 +6,13 @@
 #
 distlib==0.3.6
     # via virtualenv
-filelock==3.8.2
+filelock==3.12.0
     # via
     #   tox
     #   virtualenv
-packaging==22.0
+packaging==23.1
     # via tox
-platformdirs==2.6.0
+platformdirs==3.2.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
@@ -22,12 +22,12 @@ six==1.16.0
     # via tox
 tomli==2.0.1
     # via tox
-tox==3.27.1
+tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/ci.in
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-virtualenv==20.17.1
+virtualenv==20.22.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,20 +4,16 @@
 #
 #    make upgrade
 #
-asgiref==3.5.2
+asgiref==3.6.0
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==2.12.13
+astroid==2.15.4
     # via
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
-attrs==22.1.0
-    # via
-    #   -r requirements/quality.txt
-    #   pytest
-build==0.9.0
+build==0.10.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
@@ -43,7 +39,7 @@ code-annotations==1.3.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-coverage[toml]==6.5.0
+coverage[toml]==7.2.3
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -61,7 +57,7 @@ distlib==0.3.6
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==3.2.16
+django==3.2.18
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
@@ -73,24 +69,24 @@ django-waffle==3.0.0
     # via -r requirements/quality.txt
 edx-i18n-tools==0.9.2
     # via -r requirements/dev.in
-edx-lint==5.3.0
+edx-lint==5.3.4
     # via -r requirements/quality.txt
-exceptiongroup==1.0.4
+exceptiongroup==1.1.1
     # via
     #   -r requirements/quality.txt
     #   pytest
-filelock==3.8.2
+filelock==3.12.0
     # via
     #   -r requirements/ci.txt
     #   tox
     #   virtualenv
-inflect==6.0.2
+inflect==6.0.4
     # via jinja2-pluralize
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via
     #   -r requirements/quality.txt
     #   pytest
-isort==5.10.1
+isort==5.12.0
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -102,11 +98,11 @@ jinja2==3.1.2
     #   jinja2-pluralize
 jinja2-pluralize==0.3.0
     # via diff-cover
-lazy-object-proxy==1.8.0
+lazy-object-proxy==1.9.0
     # via
     #   -r requirements/quality.txt
     #   astroid
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via
     #   -r requirements/quality.txt
     #   jinja2
@@ -114,11 +110,11 @@ mccabe==0.7.0
     # via
     #   -r requirements/quality.txt
     #   pylint
-mock==4.0.3
+mock==5.0.2
     # via -r requirements/quality.txt
-newrelic==8.5.0
+newrelic==8.8.0
     # via -r requirements/quality.txt
-packaging==22.0
+packaging==23.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/pip-tools.txt
@@ -128,17 +124,13 @@ packaging==22.0
     #   tox
 path==16.6.0
     # via edx-i18n-tools
-pbr==5.11.0
+pbr==5.11.1
     # via
     #   -r requirements/quality.txt
     #   stevedore
-pep517==0.13.0
-    # via
-    #   -r requirements/pip-tools.txt
-    #   build
-pip-tools==6.11.0
+pip-tools==6.13.0
     # via -r requirements/pip-tools.txt
-platformdirs==2.6.0
+platformdirs==3.2.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -151,9 +143,9 @@ pluggy==1.0.0
     #   diff-cover
     #   pytest
     #   tox
-polib==1.1.1
+polib==1.2.0
     # via edx-i18n-tools
-psutil==5.9.4
+psutil==5.9.5
     # via -r requirements/quality.txt
 py==1.11.0
     # via
@@ -165,13 +157,13 @@ pycparser==2.21
     # via
     #   -r requirements/quality.txt
     #   cffi
-pydantic==1.10.2
+pydantic==1.10.7
     # via inflect
-pydocstyle==6.1.1
+pydocstyle==6.3.0
     # via -r requirements/quality.txt
-pygments==2.13.0
+pygments==2.15.1
     # via diff-cover
-pylint==2.15.8
+pylint==2.17.3
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -193,7 +185,11 @@ pylint-plugin-utils==0.7
     #   pylint-django
 pynacl==1.5.0
     # via -r requirements/quality.txt
-pytest==7.2.0
+pyproject-hooks==1.0.0
+    # via
+    #   -r requirements/pip-tools.txt
+    #   build
+pytest==7.3.1
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -204,11 +200,11 @@ pytest-django==4.5.2
     # via -r requirements/quality.txt
 python-dateutil==2.8.2
     # via -r requirements/dev.in
-python-slugify==7.0.0
+python-slugify==8.0.1
     # via
     #   -r requirements/quality.txt
     #   code-annotations
-pytz==2022.6
+pytz==2023.3
     # via
     #   -r requirements/quality.txt
     #   django
@@ -228,11 +224,11 @@ snowballstemmer==2.2.0
     # via
     #   -r requirements/quality.txt
     #   pydocstyle
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -r requirements/quality.txt
     #   django
-stevedore==4.1.1
+stevedore==5.0.0
     # via
     #   -r requirements/quality.txt
     #   code-annotations
@@ -247,36 +243,36 @@ tomli==2.0.1
     #   -r requirements/quality.txt
     #   build
     #   coverage
-    #   pep517
     #   pylint
+    #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via
     #   -r requirements/quality.txt
     #   pylint
-tox==3.27.1
+tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/ci.txt
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.txt
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   -r requirements/quality.txt
     #   astroid
     #   pydantic
     #   pylint
-virtualenv==20.17.1
+virtualenv==20.22.0
     # via
     #   -r requirements/ci.txt
     #   tox
-wheel==0.38.4
+wheel==0.40.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-wrapt==1.14.1
+wrapt==1.15.0
     # via
     #   -r requirements/quality.txt
     #   astroid

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,9 +6,9 @@
 #
 accessible-pygments==0.0.4
     # via pydata-sphinx-theme
-alabaster==0.7.12
+alabaster==0.7.13
     # via sphinx
-asgiref==3.5.2
+asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
@@ -16,36 +16,27 @@ attrs==22.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
-babel==2.11.0
-    # via
-    #   pydata-sphinx-theme
-    #   sphinx
-beautifulsoup4==4.12.0
-    # via pydata-sphinx-theme
-bleach==5.0.1
+babel==2.12.1
+    # via sphinx
+bleach==6.0.0
     # via readme-renderer
 certifi==2022.12.7
     # via requests
 cffi==1.15.1
     # via
     #   -r requirements/test.txt
-    #   cryptography
     #   pynacl
-charset-normalizer==2.1.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via -r requirements/test.txt
-commonmark==0.9.1
-    # via rich
-coverage[toml]==6.5.0
+coverage[toml]==7.2.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==38.0.4
-    # via secretstorage
 ddt==1.6.0
     # via -r requirements/test.txt
-django==3.2.16
+django==3.2.18
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -65,7 +56,9 @@ docutils==0.17.1
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
-exceptiongroup==1.0.4
+edx-sphinx-theme==3.1.0
+    # via -r requirements/doc.in
+exceptiongroup==1.1.1
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -73,57 +66,57 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==5.1.0
+importlib-metadata==6.6.0
     # via
     #   keyring
     #   twine
-iniconfig==1.1.1
+importlib-resources==5.12.0
+    # via keyring
+iniconfig==2.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
 jaraco-classes==3.2.3
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via sphinx
-keyring==23.11.0
+keyring==23.13.1
     # via twine
-markupsafe==2.1.1
+markdown-it-py==2.2.0
+    # via rich
+markupsafe==2.1.2
     # via jinja2
-mock==4.0.3
+mdurl==0.1.2
+    # via markdown-it-py
+mock==5.0.2
     # via -r requirements/test.txt
-more-itertools==9.0.0
+more-itertools==9.1.0
     # via jaraco-classes
-newrelic==8.5.0
+newrelic==8.8.0
     # via -r requirements/test.txt
-packaging==22.0
+packaging==23.1
     # via
     #   -r requirements/test.txt
     #   pydata-sphinx-theme
     #   pytest
     #   sphinx
-pbr==5.11.0
+pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-pkginfo==1.9.2
+pkginfo==1.9.6
     # via twine
 pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-psutil==5.9.4
+psutil==5.9.5
     # via -r requirements/test.txt
 pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pydata-sphinx-theme==0.13.1
-    # via sphinx-book-theme
-pygments==2.13.0
+pygments==2.15.1
     # via
     #   accessible-pygments
     #   doc8
@@ -133,7 +126,7 @@ pygments==2.13.0
     #   sphinx
 pynacl==1.5.0
     # via -r requirements/test.txt
-pytest==7.2.0
+pytest==7.3.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -142,7 +135,7 @@ pytest-cov==4.0.0
     # via -r requirements/test.txt
 pytest-django==4.5.2
     # via -r requirements/test.txt
-pytz==2022.6
+pytz==2023.3
     # via
     #   -r requirements/test.txt
     #   babel
@@ -151,7 +144,7 @@ readme-renderer==37.3
     # via
     #   -r requirements/doc.in
     #   twine
-requests==2.28.1
+requests==2.28.2
     # via
     #   requests-toolbelt
     #   sphinx
@@ -162,10 +155,8 @@ restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==12.6.0
+rich==13.3.4
     # via twine
-secretstorage==3.3.3
-    # via keyring
 six==1.16.0
     # via bleach
 snowballstemmer==2.2.0
@@ -177,15 +168,12 @@ sphinx==4.2.0
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/doc.in
-    #   pydata-sphinx-theme
-    #   sphinx-book-theme
-sphinx-book-theme==1.0.0
-    # via -r requirements/doc.in
-sphinxcontrib-applehelp==1.0.2
+    #   edx-sphinx-theme
+sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-htmlhelp==2.0.1
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
@@ -193,11 +181,11 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==4.1.1
+stevedore==5.0.0
     # via
     #   -r requirements/test.txt
     #   doc8
@@ -208,16 +196,18 @@ tomli==2.0.1
     #   pytest
 twine==4.0.2
     # via -r requirements/doc.in
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via rich
-urllib3==1.26.13
+urllib3==1.26.15
     # via
     #   requests
     #   twine
 webencodings==0.5.1
     # via bleach
-zipp==3.11.0
-    # via importlib-metadata
+zipp==3.15.0
+    # via
+    #   importlib-metadata
+    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -12,12 +12,12 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-attrs==22.1.0
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 babel==2.12.1
-    # via sphinx
+    # via
+    #   pydata-sphinx-theme
+    #   sphinx
+beautifulsoup4==4.12.2
+    # via pydata-sphinx-theme
 bleach==6.0.0
     # via readme-renderer
 certifi==2022.12.7
@@ -56,8 +56,6 @@ docutils==0.17.1
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
-edx-sphinx-theme==3.1.0
-    # via -r requirements/doc.in
 exceptiongroup==1.1.1
     # via
     #   -r requirements/test.txt
@@ -116,6 +114,8 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
+pydata-sphinx-theme==0.13.3
+    # via sphinx-book-theme
 pygments==2.15.1
     # via
     #   accessible-pygments
@@ -161,14 +161,17 @@ six==1.16.0
     # via bleach
 snowballstemmer==2.2.0
     # via sphinx
-soupsieve==2.4
+soupsieve==2.4.1
     # via beautifulsoup4
 sphinx==4.2.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/doc.in
-    #   edx-sphinx-theme
+    #   pydata-sphinx-theme
+    #   sphinx-book-theme
+sphinx-book-theme==1.0.1
+    # via -r requirements/doc.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
@@ -197,7 +200,9 @@ tomli==2.0.1
 twine==4.0.2
     # via -r requirements/doc.in
 typing-extensions==4.5.0
-    # via rich
+    # via
+    #   pydata-sphinx-theme
+    #   rich
 urllib3==1.26.15
     # via
     #   requests

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,21 +4,19 @@
 #
 #    make upgrade
 #
-build==0.9.0
+build==0.10.0
     # via pip-tools
 click==8.1.3
     # via pip-tools
-packaging==22.0
+packaging==23.1
     # via build
-pep517==0.13.0
-    # via build
-pip-tools==6.11.0
+pip-tools==6.13.0
     # via -r requirements/pip-tools.in
+pyproject-hooks==1.0.0
+    # via build
 tomli==2.0.1
-    # via
-    #   build
-    #   pep517
-wheel==0.38.4
+    # via build
+wheel==0.40.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,18 +4,14 @@
 #
 #    make upgrade
 #
-asgiref==3.5.2
+asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.12.13
+astroid==2.15.4
     # via
     #   pylint
     #   pylint-celery
-attrs==22.1.0
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 cffi==1.15.1
     # via
     #   -r requirements/test.txt
@@ -30,7 +26,7 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==1.3.0
     # via edx-lint
-coverage[toml]==6.5.0
+coverage[toml]==7.2.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -38,7 +34,7 @@ ddt==1.6.0
     # via -r requirements/test.txt
 dill==0.3.6
     # via pylint
-django==3.2.16
+django==3.2.18
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -47,47 +43,47 @@ django-crum==0.7.9
     # via -r requirements/test.txt
 django-waffle==3.0.0
     # via -r requirements/test.txt
-edx-lint==5.3.0
+edx-lint==5.3.4
     # via -r requirements/quality.in
-exceptiongroup==1.0.4
+exceptiongroup==1.1.1
     # via
     #   -r requirements/test.txt
     #   pytest
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-isort==5.10.1
+isort==5.12.0
     # via
     #   -r requirements/quality.in
     #   pylint
 jinja2==3.1.2
     # via code-annotations
-lazy-object-proxy==1.8.0
+lazy-object-proxy==1.9.0
     # via astroid
-markupsafe==2.1.1
+markupsafe==2.1.2
     # via jinja2
 mccabe==0.7.0
     # via pylint
-mock==4.0.3
+mock==5.0.2
     # via -r requirements/test.txt
-newrelic==8.5.0
+newrelic==8.8.0
     # via -r requirements/test.txt
-packaging==22.0
+packaging==23.1
     # via
     #   -r requirements/test.txt
     #   pytest
-pbr==5.11.0
+pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==2.6.0
+platformdirs==3.2.0
     # via pylint
 pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-psutil==5.9.4
+psutil==5.9.5
     # via -r requirements/test.txt
 pycodestyle==2.10.0
     # via -r requirements/quality.in
@@ -95,9 +91,9 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pydocstyle==6.1.1
+pydocstyle==6.3.0
     # via -r requirements/quality.in
-pylint==2.15.8
+pylint==2.17.3
     # via
     #   edx-lint
     #   pylint-celery
@@ -113,7 +109,7 @@ pylint-plugin-utils==0.7
     #   pylint-django
 pynacl==1.5.0
     # via -r requirements/test.txt
-pytest==7.2.0
+pytest==7.3.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -122,9 +118,9 @@ pytest-cov==4.0.0
     # via -r requirements/test.txt
 pytest-django==4.5.2
     # via -r requirements/test.txt
-python-slugify==7.0.0
+python-slugify==8.0.1
     # via code-annotations
-pytz==2022.6
+pytz==2023.3
     # via
     #   -r requirements/test.txt
     #   django
@@ -134,11 +130,11 @@ six==1.16.0
     # via edx-lint
 snowballstemmer==2.2.0
     # via pydocstyle
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==4.1.1
+stevedore==5.0.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -150,11 +146,11 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via pylint
-typing-extensions==4.4.0
+typing-extensions==4.5.0
     # via
     #   astroid
     #   pylint
-wrapt==1.14.1
+wrapt==1.15.0
     # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,19 +4,17 @@
 #
 #    make upgrade
 #
-asgiref==3.5.2
+asgiref==3.6.0
     # via
     #   -r requirements/base.txt
     #   django
-attrs==22.1.0
-    # via pytest
 cffi==1.15.1
     # via
     #   -r requirements/base.txt
     #   pynacl
 click==8.1.3
     # via -r requirements/base.txt
-coverage[toml]==6.5.0
+coverage[toml]==7.2.3
     # via pytest-cov
 ddt==1.6.0
     # via -r requirements/test.in
@@ -28,23 +26,23 @@ django-crum==0.7.9
     # via -r requirements/base.txt
 django-waffle==3.0.0
     # via -r requirements/base.txt
-exceptiongroup==1.0.4
+exceptiongroup==1.1.1
     # via pytest
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
-mock==4.0.3
+mock==5.0.2
     # via -r requirements/test.in
-newrelic==8.5.0
+newrelic==8.8.0
     # via -r requirements/base.txt
-packaging==22.0
+packaging==23.1
     # via pytest
-pbr==5.11.0
+pbr==5.11.1
     # via
     #   -r requirements/base.txt
     #   stevedore
 pluggy==1.0.0
     # via pytest
-psutil==5.9.4
+psutil==5.9.5
     # via -r requirements/base.txt
 pycparser==2.21
     # via
@@ -52,7 +50,7 @@ pycparser==2.21
     #   cffi
 pynacl==1.5.0
     # via -r requirements/base.txt
-pytest==7.2.0
+pytest==7.3.1
     # via
     #   pytest-cov
     #   pytest-django
@@ -60,15 +58,15 @@ pytest-cov==4.0.0
     # via -r requirements/test.in
 pytest-django==4.5.2
     # via -r requirements/test.in
-pytz==2022.6
+pytz==2023.3
     # via
     #   -r requirements/base.txt
     #   django
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==4.1.1
+stevedore==5.0.0
     # via -r requirements/base.txt
 tomli==2.0.1
     # via

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,8 @@ deps =
     django32: Django>=3.2,<4.0
     -r{toxinidir}/requirements/test.txt
 commands = 
-    python -Wd -m pytest {posargs}
+    python -Wd -m pytest --cov {posargs}
+    python -m coverage html
 
 [testenv:docs]
 setenv = 


### PR DESCRIPTION
### Description
- Latest version of `pip==23.1` conflict with `pip-tools` unless `pip-tools` is upgraded to `pip-tools>=6.13.0`. 
- Codecov deprecated the pypi package long ago (Feb 2022) but left it up until now.
- Updated `coverage` step since now `codecov` package has been removed.