### PR TITLE
fix: enable updating pip.txt in make upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip install -qr requirements/pip-tools.txt
 	# Make sure to compile files after any other files they include!
-	pip-compile --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
+	pip-compile --allow-unsafe --rebuild --upgrade -o requirements/pip.txt requirements/pip.in
 	pip-compile --no-emit-trusted-host --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
 	pip install -qr requirements/pip.txt
 	pip install -qr requirements/pip-tools.txt

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -12,7 +12,7 @@ filelock==3.12.0
     #   virtualenv
 packaging==23.1
     # via tox
-platformdirs==3.4.0
+platformdirs==3.5.0
     # via virtualenv
 pluggy==1.0.0
     # via tox
@@ -29,5 +29,5 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-virtualenv==20.22.0
+virtualenv==20.23.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -39,7 +39,7 @@ code-annotations==1.3.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-coverage[toml]==7.2.3
+coverage[toml]==7.2.5
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -130,7 +130,7 @@ pbr==5.11.1
     #   stevedore
 pip-tools==6.13.0
     # via -r requirements/pip-tools.txt
-platformdirs==3.4.0
+platformdirs==3.5.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -247,7 +247,7 @@ tomli==2.0.1
     #   pyproject-hooks
     #   pytest
     #   tox
-tomlkit==0.11.7
+tomlkit==0.11.8
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -264,7 +264,7 @@ typing-extensions==4.5.0
     #   astroid
     #   pydantic
     #   pylint
-virtualenv==20.22.0
+virtualenv==20.23.0
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -30,7 +30,7 @@ charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via -r requirements/test.txt
-coverage[toml]==7.2.3
+coverage[toml]==7.2.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -149,13 +149,13 @@ requests==2.29.0
     #   requests-toolbelt
     #   sphinx
     #   twine
-requests-toolbelt==0.10.1
+requests-toolbelt==1.0.0
     # via twine
 restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==13.3.4
+rich==13.3.5
     # via twine
 six==1.16.0
     # via bleach

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -1,5 +1,7 @@
 # Core dependencies for installing other packages
 
+-c constraints.txt
+
 pip
 setuptools
 wheel

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.35.1
+wheel==0.40.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==20.3
+pip==23.1.2
     # via -r requirements/pip.in
-setuptools==50.3.2
+setuptools==67.7.2
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -26,7 +26,7 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==1.3.0
     # via edx-lint
-coverage[toml]==7.2.3
+coverage[toml]==7.2.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -77,7 +77,7 @@ pbr==5.11.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==3.4.0
+platformdirs==3.5.0
     # via pylint
 pluggy==1.0.0
     # via
@@ -146,7 +146,7 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.7
+tomlkit==0.11.8
     # via pylint
 typing-extensions==4.5.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,7 +14,7 @@ cffi==1.15.1
     #   pynacl
 click==8.1.3
     # via -r requirements/base.txt
-coverage[toml]==7.2.3
+coverage[toml]==7.2.5
     # via pytest-cov
 ddt==1.6.0
     # via -r requirements/test.in


### PR DESCRIPTION
## Description
- `pip.txt` wasn't being updated in the `make upgrade` job because the `--upgrade` flag was missing in the `pip-compile` command
- It was causing the scheduled `Python Requirements Upgrade` [build](https://github.com/openedx/edx-django-utils/actions/runs/4847705622/jobs/8666288926#step:5:28) to fail due to `pip & pip-tools` conflict.