### PR TITLE
fix: fix coveragerc paths format

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,8 +4,8 @@ data_file = .coverage
 source=edx_django_utils
 omit =
     test_settings
-    *migrations*
-    *admin.py
-    *static*
-    *templates*
-    *plugins*
+    */migrations/*
+    */admin.py
+    */static/*
+    */templates/*
+    */plugins/*


### PR DESCRIPTION
## Description
- Closes https://github.com/openedx/edx-django-utils/issues/305
- Correct .coveragerc ``omit`` file paths to properly specify directories.
- Following the instructions in the https://coverage.readthedocs.io/en/7.2.5/migrating.html for the new version.