### PR TITLE
feat: remove certain cookies from responses

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     directory: "/"
     schedule:
         interval: "weekly"
+    reviewers:
+      - "openedx/arbi-bom"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,9 +14,15 @@ Change Log
 Unreleased
 ----------
 
+[5.5.0] - 2023-06-01
+--------------------
+
+Changed
+~~~~~~~
 * Switched to ``sphinx-book-theme`` as the new standard theme across all Open
   edX repos.  See https://github.com/openedx/edx-sphinx-theme/issues/184 for
   more details.
+* CookieMonitoringMiddleware will now remove cookies based on a DEPRECATED_COOKIE_PREFIXES setting
 
 
 [5.4.0] - 2023-04-12

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,7 +2,7 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "5.4.0"
+__version__ = "5.5.0"
 
 default_app_config = (
     "edx_django_utils.apps.EdxDjangoUtilsConfig"

--- a/edx_django_utils/monitoring/internal/middleware.py
+++ b/edx_django_utils/monitoring/internal/middleware.py
@@ -286,11 +286,11 @@ class CookieMonitoringMiddleware:
 
         response = self.get_response(request)
 
-        # .. setting_name: DEPRECATED_COOKIE_PREFIXES
+        # .. setting_name: COOKIE_PREFIXES_TO_REMOVE
         # .. setting_default: []
         # .. setting_description: A list of cookie prefixes. Any cookie starting with a prefix in this list
         # will be manually removed from responses (i.e. set to expire in the past)
-        deprecated_cookie_prefixes = getattr(settings, "DEPRECATED_COOKIE_PREFIXES", [])
+        deprecated_cookie_prefixes = getattr(settings, "COOKIE_PREFIXES_TO_REMOVE", [])
         yesterday = datetime.utcnow() - timedelta(days=1)
         for cookie_name in request.COOKIES.keys():
             for deprecated_cookie_prefix in deprecated_cookie_prefixes:

--- a/edx_django_utils/monitoring/internal/middleware.py
+++ b/edx_django_utils/monitoring/internal/middleware.py
@@ -295,6 +295,7 @@ class CookieMonitoringMiddleware:
         for cookie_name in request.COOKIES.keys():
             for deprecated_cookie_prefix in deprecated_cookie_prefixes:
                 if cookie_name.startswith(deprecated_cookie_prefix):
+                    log.info(f"Forcing expiration of {cookie_name}")
                     response.set_cookie(cookie_name, value='', expires=yesterday,
                                         domain=settings.BASE_COOKIE_DOMAIN)
 

--- a/edx_django_utils/monitoring/internal/middleware.py
+++ b/edx_django_utils/monitoring/internal/middleware.py
@@ -5,7 +5,6 @@ At this time, monitoring details can only be reported to New Relic.
 
 """
 import base64
-from datetime import datetime, timedelta
 import hashlib
 import json
 import logging
@@ -13,6 +12,7 @@ import math
 import platform
 import random
 import warnings
+from datetime import datetime, timedelta
 from uuid import uuid4
 
 import django

--- a/edx_django_utils/monitoring/tests/test_middleware.py
+++ b/edx_django_utils/monitoring/tests/test_middleware.py
@@ -282,7 +282,7 @@ class CookieMonitoringMiddlewareTestCase(TestCase):
         mock_logger.exception.assert_called_once_with("Unexpected error logging and monitoring cookies.")
 
     @override_settings(BASE_COOKIE_DOMAIN="localhost")
-    @override_settings(DEPRECATED_COOKIE_PREFIXES=['old_cookie'])
+    @override_settings(COOKIE_PREFIXES_TO_REMOVE=['old_cookie'])
     @patch('edx_django_utils.monitoring.internal.middleware.datetime')
     def test_deprecated_cookies_removed(self, datetime_mock):
         now = datetime.utcnow()

--- a/edx_django_utils/monitoring/tests/test_middleware.py
+++ b/edx_django_utils/monitoring/tests/test_middleware.py
@@ -4,9 +4,9 @@ Tests monitoring middleware.
 Note: CachedCustomMonitoringMiddleware is tested in ``test_custom_monitoring.py``.
 """
 import re
+from datetime import datetime, timedelta
 from unittest.mock import Mock, call, patch
 
-from datetime import datetime, timedelta
 import ddt
 from django.test import TestCase
 from django.test.client import RequestFactory


### PR DESCRIPTION
**Description:**

Updates CookieMonitoringMiddleware to remove certain cookies (specified in a setting) from responses. Removes them by setting an expiration date in the past.

**Issue:**
https://github.com/edx/edx-arch-experiments/issues/297


**Testing instructions:**
Tested by removing the `experiments_is_enterprise` cookie from CMS (it's set in LMS)

**Reviewers:**
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**

List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.