### PR TITLE
fix: treat none value as cache miss

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,8 +15,14 @@ Unreleased
 ----------
 
 Added
-
+~~~~~
 * Support added for Django 4.2
+
+Fixed
+~~~~~
+* Fixed bug where None was not properly being stored by TieredCache.
+  For backward compatibility, ``edx_django_utils.cache.disable_forced_cache_miss_for_none`` waffle switch has
+  been added, which defaults to the old broken behavior of treating None as a cache miss.
 
 [5.6.0] - 2023-07-24
 --------------------

--- a/edx_django_utils/cache/tests/test_utils.py
+++ b/edx_django_utils/cache/tests/test_utils.py
@@ -6,6 +6,8 @@ from threading import Thread
 from unittest import TestCase, mock
 
 import ddt
+from django.test import TestCase as DjangoTestCase
+from waffle.testutils import override_switch
 
 from edx_django_utils.cache.utils import (
     DEFAULT_REQUEST_CACHE_NAMESPACE,
@@ -142,7 +144,7 @@ class TestRequestCache(TestCase):  # pylint: disable=missing-class-docstring
             RequestCache(DEFAULT_REQUEST_CACHE_NAMESPACE)
 
 
-class TestTieredCache(TestCase):  # pylint: disable=missing-class-docstring
+class TestTieredCache(DjangoTestCase):  # pylint: disable=missing-class-docstring
     def setUp(self):
         super().setUp()
         self.request_cache = RequestCache()
@@ -160,6 +162,13 @@ class TestTieredCache(TestCase):  # pylint: disable=missing-class-docstring
 
     @mock.patch('django.core.cache.cache.get')
     def test_get_cached_response_django_cache_hit(self, mock_cache_get):
+        """
+        Temporary tests for cache miss when caching a None.
+
+        Temporarily we are forcing cache misses by default when caching None for
+        backward compatibility purposes. See ``disable_forced_cache_miss_for_none``
+        switch for more details.
+        """
         mock_cache_get.return_value = EXPECTED_VALUE
         cached_response = TieredCache.get_cached_response(TEST_KEY)
         self.assertTrue(cached_response.is_found)
@@ -167,6 +176,38 @@ class TestTieredCache(TestCase):  # pylint: disable=missing-class-docstring
 
         cached_response = self.request_cache.get_cached_response(TEST_KEY)
         self.assertTrue(cached_response.is_found, 'Django cache hit should cache value in request cache.')
+
+    @override_switch('edx_django_utils.cache.disable_forced_cache_miss_for_none', True)
+    def test_get_cached_response_hit_with_cached_none(self):
+        """
+        Tests cache hit when caching a None.
+
+        For rollout, this test relies on ``disable_forced_cache_miss_for_none`` switch to be on, because
+        by default we are temporarily forcing cache misses for backward compatibility.
+        """
+        TieredCache.set_all_tiers(TEST_KEY, None)
+        # Test retrieval from tier 1: RequestCache
+        cached_response = TieredCache.get_cached_response(TEST_KEY)
+        self.assertTrue(cached_response.is_found)
+        self.assertEqual(cached_response.value, None)
+
+        self.request_cache.clear()
+        # Test retrieval from tier 2: Django Cache
+        cached_response = TieredCache.get_cached_response(TEST_KEY)
+        self.assertTrue(cached_response.is_found)
+        self.assertEqual(cached_response.value, None)
+
+    def test_get_cached_response_miss_with_cached_none(self):
+        TieredCache.set_all_tiers(TEST_KEY, None)
+        # Test retrieval from tier 1: RequestCache
+        cached_response = TieredCache.get_cached_response(TEST_KEY)
+        self.assertTrue(cached_response.is_found)
+        self.assertEqual(cached_response.value, None)
+
+        self.request_cache.clear()
+        # Test retrieval from tier 2: Django Cache
+        cached_response = TieredCache.get_cached_response(TEST_KEY)
+        self.assertFalse(cached_response.is_found)
 
     @mock.patch('django.core.cache.cache.get')
     def test_get_cached_response_force_cache_miss(self, mock_cache_get):

--- a/edx_django_utils/cache/utils.py
+++ b/edx_django_utils/cache/utils.py
@@ -265,10 +265,11 @@ class TieredCache:
 
         cached_value = django_cache.get(key, _CACHE_MISS)
 
-        if cached_value == _CACHED_NONE and not TieredCache._is_forced_cache_miss_for_none_disabled():
-            cached_value = _CACHE_MISS
-        elif cached_value == _CACHED_NONE:
-            cached_value = None
+        if cached_value == _CACHED_NONE:
+            if TieredCache._is_forced_cache_miss_for_none_disabled():
+                cached_value = None
+            else:
+                cached_value = _CACHE_MISS
 
         is_found = cached_value is not _CACHE_MISS
         return CachedResponse(is_found, key, cached_value)

--- a/edx_django_utils/cache/utils.py
+++ b/edx_django_utils/cache/utils.py
@@ -266,6 +266,14 @@ class TieredCache:
         cached_value = django_cache.get(key, _CACHE_MISS)
 
         if cached_value == _CACHED_NONE:
+            # Avoiding circular import
+            from edx_django_utils.monitoring.internal.utils import \
+                set_custom_attribute  # isort:skip, pylint: disable=cyclic-import, import-outside-toplevel
+
+            # .. custom_attribute_name: retrieved_cached_none
+            # .. custom_attribute_description: Temporary attribute to see when a None would
+            #      have been retrieved, so we know what will be affected by the toggle.
+            set_custom_attribute('retrieved_cached_none', True)
             if TieredCache._is_forced_cache_miss_for_none_disabled():
                 cached_value = None
             else:

--- a/edx_django_utils/cache/utils.py
+++ b/edx_django_utils/cache/utils.py
@@ -4,6 +4,7 @@ Cache utilities.
 import hashlib
 import threading
 
+import waffle  # pylint: disable=invalid-django-waffle-import
 from django.core.cache import cache as django_cache
 from django.core.cache.backends.base import DEFAULT_TIMEOUT
 from django.utils.encoding import force_str
@@ -14,6 +15,7 @@ DEFAULT_REQUEST_CACHE_NAMESPACE = f'{DEFAULT_NAMESPACE}.default'
 SHOULD_FORCE_CACHE_MISS_KEY = 'edx_django_utils.cache.should_force_cache_miss'
 
 _CACHE_MISS = object()
+_CACHED_NONE = 'CACHED_NONE'
 
 
 def get_cache_key(**kwargs):
@@ -210,7 +212,10 @@ class TieredCache:
 
         """
         DEFAULT_REQUEST_CACHE.set(key, value)
-        django_cache.set(key, value, django_cache_timeout)
+        cached_value = value
+        if value is None:
+            cached_value = _CACHED_NONE
+        django_cache.set(key, cached_value, django_cache_timeout)
 
     @staticmethod
     def delete_all_tiers(key):
@@ -259,6 +264,12 @@ class TieredCache:
             return CachedResponse(is_found=False, key=key, value=None)
 
         cached_value = django_cache.get(key, _CACHE_MISS)
+
+        if cached_value == _CACHED_NONE and not TieredCache._is_forced_cache_miss_for_none_disabled():
+            cached_value = _CACHE_MISS
+        elif cached_value == _CACHED_NONE:
+            cached_value = None
+
         is_found = cached_value is not _CACHE_MISS
         return CachedResponse(is_found, key, cached_value)
 
@@ -302,6 +313,25 @@ class TieredCache:
         """
         cached_response = DEFAULT_REQUEST_CACHE.get_cached_response(SHOULD_FORCE_CACHE_MISS_KEY)
         return False if not cached_response.is_found else cached_response.value
+
+    @staticmethod
+    def _is_forced_cache_miss_for_none_disabled():
+        """
+        Returns True if disable_forced_cache_miss_for_none is on, and False otherwise.
+        """
+        # .. toggle_name: edx_django_utils.cache.disable_forced_cache_miss_for_none
+        # .. toggle_implementation: WaffleSwitch
+        # .. toggle_default: False
+        # .. toggle_description: By default, this toggle will replicate an existing bug by forcing
+        #      cache misses when setting None. Set the toggle to True to disable this behavior,
+        #      which fixes the bug and returns None when None was cached. This toggle is
+        #      being used for backward compatibility during rollout, until the toggle and old
+        #      broken behavior can be removed.
+        # .. toggle_use_cases: temporary
+        # .. toggle_creation_date: 2023-08-02
+        # .. toggle_target_removal_date: 2023-09-01
+        # .. toggle_tickets: https://github.com/openedx/edx-django-utils/issues/333
+        return waffle.switch_is_active('edx_django_utils.cache.disable_forced_cache_miss_for_none')
 
 
 class CachedResponseError(Exception):


### PR DESCRIPTION
**Description**
- We are replacing [(issue link)](https://github.com/edx/edx-arch-experiments/issues/92) `Python-memcache` with `pymemcache`.
- While doing that [(PR link)](https://github.com/edx/edx-internal/pull/8896) we faced the following error
```
  File "/edx/app/edxapp/edx-platform/xmodule/video_block/video_block.py", line 244, in student_view
    fragment = Fragment(self.get_html())
  File "/edx/app/edxapp/edx-platform/xmodule/video_block/video_block.py", line 355, in get_html
    branding_info = BrandingInfoConfig.get_config().get(user_location)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/branding/models.py", line 54, in get_config
    return json.loads(info.configuration) if info.enabled else {}
AttributeError: 'NoneType' object has no attribute 'enabled'
```
- The reason for the error is that at the following line [(line link)](https://github.com/openedx/edx-platform/blob/master/lms/djangoapps/branding/models.py#L54), the `info` variable is `None`
- This value for `info` is coming from `Tiered cache` [(link)](https://github.com/openedx/django-config-models/blob/master/config_models/models.py#L133)
- The Tiered cache is returning `None` (using `pymemcache` as backend) [(link)](https://github.com/openedx/edx-django-utils/blob/v5.5.0/edx_django_utils/cache/utils.py#L261). This `None` causes the exception.
- Previously, it wasn't creating any issue as `python-memcache` was treating `None` as `CACHE_MISS`
- Now, in this PR, we are explicitly treating `None` as `cache miss`

