### PR TITLE
feat: docker-based local work without lms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,98 @@
+# Docker in this repo is only supported for running tests locally
+# as an alternative to virtualenv natively
+FROM ubuntu:focal as app
+LABEL org.opencontainers.image.authors="sre@edx.org"
+
+
+# Packages installed:
+# git; Used to pull in particular requirements from github rather than pypi,
+# and to check the sha of the code checkout.
+
+# build-essentials; so we can use make with the docker container
+
+# language-pack-en locales; ubuntu locale support so that system utilities have a consistent
+# language and time zone.
+
+# python; ubuntu doesnt ship with python, so this is the python we will use to run the application
+
+# python3-pip; install pip to install application requirements.txt files
+
+# pkg-config
+#     mysqlclient>=2.2.0 requires this (https://github.com/PyMySQL/mysqlclient/issues/620)
+
+# libmysqlclient-dev; to install header files needed to use native C implementation for
+# MySQL-python for performance gains.
+
+# libssl-dev; # mysqlclient wont install without this.
+
+# python3-dev; to install header files for python extensions; much wheel-building depends on this
+
+# gcc; for compiling python extensions distributed with python packages like mysql-client
+
+# If you add a package here please include a comment above describing what it is used for
+RUN apt-get update && apt-get -qy install --no-install-recommends \
+ language-pack-en \
+ locales \
+ python3.8 \
+ python3-pip \
+ python3.8-venv \
+ pkg-config \
+ libmysqlclient-dev \
+ libssl-dev \
+ python3-dev \
+ gcc \
+ build-essential \
+ git \
+ curl
+
+
+RUN pip install --upgrade pip setuptools
+# delete apt package lists because we do not need them inflating our image
+RUN rm -rf /var/lib/apt/lists/*
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+ENV DJANGO_SETTINGS_MODULE test_settings
+
+# Env vars: path
+ENV VIRTUAL_ENV='/edx/app/venvs/edx-django-utils'
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV PATH="/edx/app/edx-django-utils/node_modules/.bin:${PATH}"
+ENV PATH="/edx/app/edx-django-utils/bin:${PATH}"
+ENV PATH="/edx/app/nodeenv/bin:${PATH}"
+
+RUN useradd -m --shell /bin/false app
+
+WORKDIR /edx/app/edx-django-utils
+
+RUN python3.8 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Copy the requirements explicitly even though we copy everything below
+# this prevents the image cache from busting unless the dependencies have changed.
+COPY requirements/ /edx/app/edx-django-utils/requirements/
+
+# Dependencies are installed as root so they cannot be modified by the application user.
+RUN pip install -r requirements/dev.txt
+RUN pip install nodeenv
+
+# Set up a Node environment and install Node requirements.
+# Must be done after Python requirements, since nodeenv is installed
+# via pip.
+# The node environment is already 'activated' because its .../bin was put on $PATH.
+RUN nodeenv /edx/app/nodeenv --node=18.15.0 --prebuilt
+
+RUN mkdir -p /edx/var/log
+
+# Code is owned by root so it cannot be modified by the application user.
+# So we copy it before changing users.
+USER app
+
+# This line is after the requirements so that changes to the code will not
+# bust the image cache
+COPY . /edx/app/edx-django-utils
+

--- a/Makefile
+++ b/Makefile
@@ -82,3 +82,8 @@ validate: quality test ## run tests and quality checks
 
 selfcheck: ## check that the Makefile is well-formed
 	@echo "The Makefile is well-formed."
+
+## Docker in this repo is only supported for running tests locally
+## as an alternative to virtualenv natively
+test-shell: ## Run a shell, as root, on the specified service container
+	docker-compose run -u 0 test-shell env TERM=$(TERM) /bin/bash

--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,14 @@ The full documentation is in the docs directory, and is published to https://edx
 Getting Started
 ---------------
 
+Local testing
+~~~~~~~~~~~~~
+Two options are available for testing changes locally:
+
+First, via `make test-shell` a dockerized development envrionment can be launched to run `pytest` and do basic migration work.
+
+Second, a local copy of the package can be installed into edx-platform. For example, if using devstack, copy or clone your branch into <devstack-parent>/src/edx-django-utils. Then, in an lms or cms shell, run ``pip install -e /edx/src/edx-django-utils``.  The plug-in configuration will automatically be picked up once installed, and changes will be hot reloaded.
+
 One Time Setup
 ~~~~~~~~~~~~~~
 .. code-block::

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+# Docker in this repo is only supported for running tests locally
+# as an alternative to virtualenv natively
+version: "2.1"
+services:
+  test-shell:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: django-utils.test.app
+    hostname: app.test.django-utils
+    volumes:
+      - .:/edx/app/edx-django-utils
+
+    networks:
+      - devstack_default
+    # Allows attachment to this container using 'docker attach <containerID>'.
+    stdin_open: true
+    tty: true
+    environment:
+      DJANGO_SETTINGS_MODULE: test_settings
+
+networks:
+  devstack_default:
+    external: true


### PR DESCRIPTION
**Description:**

Adds a `make test-shell` which launches a dockerized version of the local dev environment - rather than using a local virtualenv.

~ Working from https://github.com/openedx/edx-enterprise/pull/1467 ~

There are sometimes benefits and conveniences to having a containerized local environment versus setting up and maintaining python, virtualenv, and system dependencies (mysql-dev, etc) natively. Sometimes installing your code into the LMS container extends your testing cycle past your patience. Here is some docker/makefile config to enable make test-shell to launch a containerized environment containing your local development code so you can make test / make upgrade / 'profit' / etc inside a container.


**Installation instructions:**

If running into issues with `make test-shell`, try running:
`docker-compose build --no-cache`

**Testing instructions:**

1. run `make test-shell`
2. run 'pytest'
3. run 'make validate`

**Reviewers:**
- [ ] @johnnagro 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**

List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
