### PR TITLE
docs: Hint regarding plugin_app

### DIFF
--- a/edx_django_utils/plugins/docs/how_tos/how_to_create_a_plugin_app.rst
+++ b/edx_django_utils/plugins/docs/how_tos/how_to_create_a_plugin_app.rst
@@ -32,7 +32,7 @@ file::
 
 3. (optional, but recommended) Create a top-level settings/ directory with common.py and production.py modules. This will allow you to use the PluginSettings.CONFIG option as written below.
 
-4. configure the Plugin App in their AppConfig. Note that in this example, we are explicitly configuring plugins for use in edx-platform. If your plugin is going to be used in another IDA, you may have different project and settings types. You will need to look at the IDA in question for what values it expects. You may want to add new values to the relevant enums.
+4. configure the Plugin App in their AppConfig. The app must have a ``plugin_app`` field set to a dictionary, even if the dictionary is empty. Note that in this example, we are explicitly configuring plugins for use in edx-platform. If your plugin is going to be used in another IDA, you may have different project and settings types. You will need to look at the IDA in question for what values it expects. You may want to add new values to the relevant enums.
 
 class::
 


### PR DESCRIPTION
Make it explicit that plugin_app is a required field even if it is empty.
