### PR TITLE
feat: Change get_plugin_apps to log at info level with more detail

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,13 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[5.8.0] - 2023-11-03
+--------------------
+
+Changed
+~~~~~~~
+* Adjusted ``get_plugin_apps`` to log at info level rather than debug and with more detail, though with a comment that this may not actually end up logging.
+
 [5.7.0] - 2023-08-04
 --------------------
 

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,7 +2,7 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "5.7.0"
+__version__ = "5.8.0"
 
 default_app_config = (
     "edx_django_utils.apps.EdxDjangoUtilsConfig"

--- a/edx_django_utils/plugins/plugin_apps.py
+++ b/edx_django_utils/plugins/plugin_apps.py
@@ -23,5 +23,7 @@ def get_plugin_apps(project_type):
         if getattr(app_config, constants.PLUGIN_APP_CLASS_ATTRIBUTE_NAME, None)
         is not None
     ]
-    log.debug("Plugin Apps: Found %s", plugin_apps)
+    # Note: This may not actually get logged; in edx-platform at least, logging seems to be
+    # set at WARN at the time this is actually called.
+    log.info(f"WARN: Plugin apps: For project type {project_type!r}, found {plugin_apps!r}")
     return plugin_apps


### PR DESCRIPTION
In edx-platform I found that this doesn't actually log unless I change it to `log.warning`, but... it seems worth changing this in case we get logging levels to work differently during service startup. (If nothing else, the comment may help the next person who is debugging plugins.)

-----

**Merge checklist:**
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
