### PR TITLE
build: bump version to 5.10.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
-[5.10.0] - 2024-01-02
+[5.10.1] - 2024-01-17
 ---------------------
 
 Added

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,7 +2,7 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "5.10.0"
+__version__ = "5.10.1"
 
 default_app_config = (
     "edx_django_utils.apps.EdxDjangoUtilsConfig"


### PR DESCRIPTION
**Description:**

Follow-up from https://github.com/openedx/edx-django-utils/pull/369, where the version didn't get bumped in init.py.  We need to bump it up to 5.10.1 to link to a new version tag to trigger PyPi publishing action. 