### PR TITLE
build: Remove tests/ stub; make `make test-all` work right

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,9 +69,6 @@ docs/edx_django_utils.*.rst
 requirements/private.in
 requirements/private.txt
 
-# tox environment temporary artifacts
-tests/__init__.py
-
 # Development task artifacts
 default.db
 

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,7 @@ test: clean ## run tests in the current virtualenv
 diff_cover: test ## find diff lines that need test coverage
 	diff-cover coverage.xml
 
-test-all: ## run tests on every supported Python/Django combination
-	tox -e quality
+test-all: clean ## run quality checks as well as tests on every supported Python/Django combination
 	tox
 
 validate: quality test ## run tests and quality checks

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -1,7 +1,0 @@
-"""
-Test utilities.
-
-Since py.test discourages putting __init__.py into test directory (i.e. making tests a package)
-one cannot import from anywhere under tests folder. However, some utility classes/methods might be useful
-in multiple test modules (i.e. factoryboy factories, base test classes). So this package is the place to put them.
-"""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,0 @@
-#!/usr/bin/env python
-"""
-Tests for the `edx-django-utils` models module.
-"""

--- a/tox.ini
+++ b/tox.ini
@@ -76,12 +76,10 @@ deps =
     -r{toxinidir}/requirements/quality.txt
      setuptools
 commands =
-    touch tests/__init__.py
-    pylint edx_django_utils tests test_utils manage.py setup.py
-    rm tests/__init__.py
-    pycodestyle edx_django_utils tests manage.py setup.py
-    pydocstyle edx_django_utils tests manage.py setup.py
-    isort --check-only --diff tests test_utils edx_django_utils manage.py setup.py test_settings.py
+    pylint edx_django_utils test_utils manage.py setup.py
+    pycodestyle edx_django_utils manage.py setup.py
+    pydocstyle edx_django_utils manage.py setup.py
+    isort --check-only --diff test_utils edx_django_utils manage.py setup.py test_settings.py
     make selfcheck
 
 [testenv:isort]
@@ -90,4 +88,4 @@ allowlist_externals =
 deps =
     -r{toxinidir}/requirements/quality.txt
 commands =
-    isort tests test_utils edx_django_utils manage.py setup.py test_settings.py
+    isort test_utils edx_django_utils manage.py setup.py test_settings.py

--- a/tox.ini
+++ b/tox.ini
@@ -76,10 +76,10 @@ deps =
     -r{toxinidir}/requirements/quality.txt
      setuptools
 commands =
-    pylint edx_django_utils test_utils manage.py setup.py
+    pylint edx_django_utils manage.py setup.py
     pycodestyle edx_django_utils manage.py setup.py
     pydocstyle edx_django_utils manage.py setup.py
-    isort --check-only --diff test_utils edx_django_utils manage.py setup.py test_settings.py
+    isort --check-only --diff edx_django_utils manage.py setup.py test_settings.py
     make selfcheck
 
 [testenv:isort]
@@ -88,4 +88,4 @@ allowlist_externals =
 deps =
     -r{toxinidir}/requirements/quality.txt
 commands =
-    isort test_utils edx_django_utils manage.py setup.py test_settings.py
+    isort edx_django_utils manage.py setup.py test_settings.py


### PR DESCRIPTION
- The `tests/__init__.py` create/delete thing seems to have been a workaround for something that's no longer relevant, so just remove it.
- The `test-all` target needed to depend on `clean` so that `build/lib` wouldn't stick around and confuse pytest, and the recipe needed to be pruned down to just `tox` because otherwise we'd run the quality checks twice. (`quality` is in the tox.ini default env list.)

**Merge checklist:**
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
