### PR TITLE
fix: Update URL for OEP reference in cache README

### DIFF
--- a/edx_django_utils/cache/README.rst
+++ b/edx_django_utils/cache/README.rst
@@ -3,7 +3,7 @@ Cache Utils
 
 Cache utilities that implement `OEP-0022: Caching in Django`_.
 
-.. _`OEP-0022: Caching in Django`: https://github.com/openedx/open-edx-proposals/blob/master/oeps/oep-0022-bp-django-caches.rst
+.. _`OEP-0022: Caching in Django`: https://github.com/openedx/open-edx-proposals/blob/master/oeps/best-practices/oep-0022-bp-django-caches.rst
 
 get_cache_key
 -------------


### PR DESCRIPTION
**Description:**

Updates the URL in the `README` for cache to point to the current location of OEP-0022.

**JIRA:**

[XXX-XXXX](https://openedx.atlassian.net/browse/XXX-XXXX)

**Dependencies:**

List dependencies on other outstanding PRs, issues, etc.

**Merge deadline:**

List merge deadline (if any)

**Installation instructions:**

List any non-trivial installation
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Reviewers:**
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**

List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
