### PR TITLE
build: Don't fail the build if codecov is having a bad day

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,4 +42,4 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         flags: unittests
-        fail_ci_if_error: true
+        fail_ci_if_error: false # codecov is flaky; don't block merges on this


### PR DESCRIPTION
We've been getting a lot of server errors and rate-limiting issues preventing merges. Until we can get a better option than codecov, let's just prevent it from breaking CI.