### PR TITLE
fix: add default value while getting content type header

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,12 +11,17 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[5.14.1] - 2024-05-22
+---------------------
+Fixed
+~~~~~
+* Added default value while getting content-type header to avoid KeyError.
+
 [5.14.0] - 2024-05-22
 ---------------------
 Added
 ~~~~~
 * Added middleware named ``FrontendMonitoringMiddleware`` for inserting frontend monitoring HTML script tags to response, configured by new Django setting ``OPENEDX_TELEMETRY_FRONTEND_SCRIPTS``.
-
 
 [5.13.0] - 2024-04-30
 ---------------------

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,7 +2,7 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "5.14.0"
+__version__ = "5.14.1"
 
 default_app_config = (
     "edx_django_utils.apps.EdxDjangoUtilsConfig"

--- a/edx_django_utils/monitoring/internal/middleware.py
+++ b/edx_django_utils/monitoring/internal/middleware.py
@@ -476,7 +476,9 @@ class FrontendMonitoringMiddleware:
     def __call__(self, request):
         response = self.get_response(request)
 
-        if response.status_code != 200 or not response['Content-Type'].startswith('text/html'):
+        content_type = response.headers.get('Content-Type', '')
+
+        if response.status_code != 200 or not content_type.startswith('text/html'):
             return response
 
         # .. setting_name: OPENEDX_TELEMETRY_FRONTEND_SCRIPTS


### PR DESCRIPTION
**Description:**

- Add default value while getting content-type header to avoid KeyError.


**Reviewers:**
- [x] tag reviewer

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**

List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
