### PR TITLE
Update Content-Length header in frontend monitoring middleware also adds waffle switch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,13 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[5.14.2] - 2024-05-31
+---------------------
+Fixed
+~~~~~
+* FrontendMonitoringMiddleware now updates the Content-Length header if its already set.
+* FrontendMonitoringMiddleware will now be enabled once waffle switch named ``edx_django_utils.monitoring.enable_frontend_monitoring_middleware`` is enabled.
+
 [5.14.1] - 2024-05-22
 ---------------------
 Fixed

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,7 +2,7 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "5.14.1"
+__version__ = "5.14.2"
 
 default_app_config = (
     "edx_django_utils.apps.EdxDjangoUtilsConfig"

--- a/edx_django_utils/monitoring/README.rst
+++ b/edx_django_utils/monitoring/README.rst
@@ -108,6 +108,7 @@ Frontend Monitoring Middleware
 --------------------------------
 
 This middleware ``FrontendMonitoringMiddleware`` inserts frontend monitoring related HTML script tags to the response, see docstring for details.
+In addition to adding the FrontendMonitoringMiddleware, you will need to enable a waffle switch ``edx_django_utils.monitoring.enable_frontend_monitoring_middleware`` to enable the frontend monitoring.
 
 Monitoring Memory Usage
 -----------------------

--- a/edx_django_utils/monitoring/internal/middleware.py
+++ b/edx_django_utils/monitoring/internal/middleware.py
@@ -16,6 +16,7 @@ import django
 import psutil
 import waffle  # pylint: disable=invalid-django-waffle-import
 from django.conf import settings
+from django.core.exceptions import MiddlewareNotUsed
 from django.utils.deprecation import MiddlewareMixin
 
 from edx_django_utils.cache import RequestCache
@@ -471,14 +472,14 @@ class FrontendMonitoringMiddleware:
     Middleware for adding the frontend monitoring scripts to the response.
     """
     def __init__(self, get_response):
+        # Disable the middleware if flag isn't enabled
+        if not self._is_enabled():
+            raise MiddlewareNotUsed
+
         self.get_response = get_response
 
     def __call__(self, request):
         response = self.get_response(request)
-
-        # Disable the middleware if flag isn't enabled
-        if not self._is_enabled():
-            return response
 
         content_type = response.headers.get('Content-Type', '')
         content_disposition = response.headers.get('Content-Disposition')

--- a/edx_django_utils/monitoring/internal/middleware.py
+++ b/edx_django_utils/monitoring/internal/middleware.py
@@ -476,6 +476,10 @@ class FrontendMonitoringMiddleware:
     def __call__(self, request):
         response = self.get_response(request)
 
+        # Disable the middleware if flag isn't enabled
+        if not self._is_enabled():
+            return response
+
         content_type = response.headers.get('Content-Type', '')
         content_disposition = response.headers.get('Content-Disposition')
 
@@ -531,6 +535,12 @@ class FrontendMonitoringMiddleware:
 
         # Don't add the script if both head and body tag is missing.
         return content
+
+    def _is_enabled(self):
+        """
+        Returns whether this middleware is enabled.
+        """
+        return waffle.switch_is_active('edx_django_utils.monitoring.enable_frontend_monitoring_middleware')
 
 
 # This function should be cleaned up and made into a general logging utility, but it will first

--- a/edx_django_utils/monitoring/tests/test_middleware.py
+++ b/edx_django_utils/monitoring/tests/test_middleware.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, call, patch
 
 import ddt
 from django.http import HttpRequest, HttpResponse, JsonResponse
+from django.core.exceptions import MiddlewareNotUsed
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
@@ -342,11 +343,11 @@ class FrontendMonitoringMiddlewareTestCase(TestCase):
         """
         original_html = '<head></head>'
         with override_settings(OPENEDX_TELEMETRY_FRONTEND_SCRIPTS=self.script):
-            middleware = FrontendMonitoringMiddleware(lambda r: HttpResponse(original_html, content_type='text/html'))
-            response = middleware(HttpRequest())
-        # Assert that the response content remains unchanged if flag isn't enabled
-        assert self.script.encode() not in response.content
-        assert original_html.encode() == response.content
+            self.assertRaises(
+                MiddlewareNotUsed,
+                FrontendMonitoringMiddleware,
+                lambda r: HttpResponse(original_html, content_type='text/html')
+            )
 
     @override_switch('edx_django_utils.monitoring.enable_frontend_monitoring_middleware', True)
     def test_frontend_middleware_with_waffle_enabled(self):

--- a/edx_django_utils/monitoring/tests/test_middleware.py
+++ b/edx_django_utils/monitoring/tests/test_middleware.py
@@ -7,8 +7,8 @@ import re
 from unittest.mock import Mock, call, patch
 
 import ddt
-from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.core.exceptions import MiddlewareNotUsed
+from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
@@ -425,7 +425,7 @@ class FrontendMonitoringMiddlewareTestCase(TestCase):
     @override_switch('edx_django_utils.monitoring.enable_frontend_monitoring_middleware', True)
     def test_frontend_middleware_content_length_header_already_set(self):
         """
-        Test that middleware updates the Centent-Length header, when its already set.
+        Test that middleware updates the Content-Length header, when its already set.
         """
         original_html = '<head></head>'
         with override_settings(OPENEDX_TELEMETRY_FRONTEND_SCRIPTS=self.script):
@@ -434,7 +434,7 @@ class FrontendMonitoringMiddlewareTestCase(TestCase):
             response = middleware(HttpRequest())
         # Assert that the response content contains script tag
         assert self.script.encode() in response.content
-        # Assert that the Centent-Length header is updated and script length is added.
+        # Assert that the Content-Length header is updated and script length is added.
         assert response.headers.get('Content-Length') == str(len(original_html) + len(self.script))
 
     @override_switch('edx_django_utils.monitoring.enable_frontend_monitoring_middleware', True)
@@ -448,5 +448,5 @@ class FrontendMonitoringMiddlewareTestCase(TestCase):
             response = middleware(HttpRequest())
         # Assert that the response content contains script tag
         assert self.script.encode() in response.content
-        # Assert that the Centent-Length header isn't updated, when not set already
+        # Assert that the Content-Length header isn't updated, when not set already
         assert response.headers.get('Content-Length') is None


### PR DESCRIPTION
**Description:**

- This adds the functionality to update Content-Length header if already set to avoid content trimming issue.
- Add waffle switch in frontend monitoring middleware

**Reviewers:**
- [x] tag reviewer

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**

List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
