### PR TITLE
feat: Create manual spans for monitoring backends.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,12 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[5.15.0] - 2024-07-29
+---------------------
+Added
+~~~~~
+* Added Datadog implementation of ``function_trace`` and allowed implementation to be configurable.
+
 [5.14.2] - 2024-05-31
 ---------------------
 Fixed

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,7 +2,7 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "5.14.2"
+__version__ = "5.15.0"
 
 default_app_config = (
     "edx_django_utils.apps.EdxDjangoUtilsConfig"

--- a/edx_django_utils/monitoring/README.rst
+++ b/edx_django_utils/monitoring/README.rst
@@ -28,7 +28,11 @@ Feature support matrix for built-in telemetry backends:
      - ✅ (on root span)
      - ✅ (on current span)
      - ✅ (on root span)
-   * - Retrieve and manipulate spans (``function_trace``, ``get_current_transaction``, ``ignore_transaction``, ``set_monitoring_transaction_name``)
+   * - Create a new span (``function_trace``)
+     - ✅
+     - ❌
+     - ✅
+   * - Retrieve and manipulate spans (``get_current_transaction``, ``ignore_transaction``, ``set_monitoring_transaction_name``)
      - ✅
      - ❌
      - ❌

--- a/edx_django_utils/monitoring/__init__.py
+++ b/edx_django_utils/monitoring/__init__.py
@@ -17,15 +17,11 @@ from .internal.middleware import (
     FrontendMonitoringMiddleware,
     MonitoringMemoryMiddleware
 )
-from .internal.transactions import (
-    function_trace,
-    get_current_transaction,
-    ignore_transaction,
-    set_monitoring_transaction_name
-)
+from .internal.transactions import get_current_transaction, ignore_transaction, set_monitoring_transaction_name
 from .internal.utils import (
     accumulate,
     background_task,
+    function_trace,
     increment,
     record_exception,
     set_custom_attribute,

--- a/edx_django_utils/monitoring/internal/transactions.py
+++ b/edx_django_utils/monitoring/internal/transactions.py
@@ -10,9 +10,6 @@ Usage:
 
 Please remember to expose any new methods in the `__init__.py` file.
 """
-
-from contextlib import contextmanager
-
 try:
     import newrelic.agent
 except ImportError:
@@ -39,28 +36,6 @@ def ignore_transaction():
     """
     if newrelic:  # pragma: no cover
         newrelic.agent.ignore_transaction()
-
-
-@contextmanager
-def function_trace(function_name):
-    """
-    Wraps a chunk of code that we want to appear as a separate, explicit,
-    segment in our monitoring tools.
-    """
-    # Not covering this because if we mock it, we're not really testing anything
-    # anyway. If something did break, it should show up in tests for apps that
-    # use this code with newrelic enabled, on whatever version of newrelic they
-    # run.
-    if newrelic:  # pragma: no cover
-        if newrelic.version_info[0] >= 5:
-            with newrelic.agent.FunctionTrace(function_name):
-                yield
-        else:
-            nr_transaction = newrelic.agent.current_transaction()
-            with newrelic.agent.FunctionTrace(nr_transaction, function_name):
-                yield
-    else:
-        yield
 
 
 class MonitoringTransaction():


### PR DESCRIPTION
**Ticket:**
https://github.com/edx/edx-arch-experiments/issues/658

**Description:**

This adds a new context manager for creating manual spans across our various backends. It adds in an interface for passing through arbitrary backend data because Datadog, New Relic, and OTEL all have different interfaces for creating these spans.

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**
