### PR TITLE
feat: Add root span tagging for exceptions.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,18 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[5.16.0] - 2024-09-27
+---------------------
+Added
+~~~~~
+* Added a new method to backends for ``tag_root_span_with_error`` and added Datadog implementation of the functionality.
+* Uses the new method to tag the root span when processing exceptions.
+
+Changed
+~~~~~~~
+* Renamed ``CachedCustomMonitoringMiddleware`` to ``MonitoringSupportMiddleware`` and deprecated the old name. It will be removed in a future release.
+
+
 [5.15.0] - 2024-07-29
 ---------------------
 Added

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,7 +2,7 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "5.15.0"
+__version__ = "5.16.0"
 
 default_app_config = (
     "edx_django_utils.apps.EdxDjangoUtilsConfig"

--- a/edx_django_utils/monitoring/__init__.py
+++ b/edx_django_utils/monitoring/__init__.py
@@ -15,7 +15,8 @@ from .internal.middleware import (
     CookieMonitoringMiddleware,
     DeploymentMonitoringMiddleware,
     FrontendMonitoringMiddleware,
-    MonitoringMemoryMiddleware
+    MonitoringMemoryMiddleware,
+    MonitoringSupportMiddleware
 )
 from .internal.transactions import get_current_transaction, ignore_transaction, set_monitoring_transaction_name
 from .internal.utils import (

--- a/edx_django_utils/monitoring/internal/middleware.py
+++ b/edx_django_utils/monitoring/internal/middleware.py
@@ -70,9 +70,12 @@ class DeploymentMonitoringMiddleware:
         _set_custom_attribute('python_version', platform.python_version())
 
 
-class CachedCustomMonitoringMiddleware(MiddlewareMixin):
+class MonitoringSupportMiddleware(MiddlewareMixin):
     """
-    Middleware batch reports cached custom attributes at the end of a request.
+    Middleware to support monitoring.
+
+    1. Middleware batch reports cached custom attributes at the end of a request.
+    2. Middleware adds error span tags to the root span.
 
     Make sure to add below the request cache in MIDDLEWARE.
 
@@ -130,6 +133,13 @@ class CachedCustomMonitoringMiddleware(MiddlewareMixin):
         for key, value in attributes_cache.data.items():
             _set_custom_attribute(key, value)
 
+    def _tag_root_span_with_error(self, exception):
+        """
+        Tags the root span with the exception information for all configured backends.
+        """
+        for backend in configured_backends():
+            backend.tag_root_span_with_error(exception)
+
     # Whether or not there was an exception, report any custom NR attributes that
     # may have been collected.
 
@@ -145,6 +155,16 @@ class CachedCustomMonitoringMiddleware(MiddlewareMixin):
         Django middleware handler to process an exception
         """
         self._batch_report()
+        self._tag_root_span_with_error(exception)
+
+
+class CachedCustomMonitoringMiddleware(MonitoringSupportMiddleware):
+    """
+    DEPRECATED: Use MonitoringSupportMiddleware instead.
+
+    This is the old name for the MonitoringSupportMiddleware. We are keeping it
+    around for backwards compatibility until it can be fully removed.
+    """
 
 
 def _set_custom_attribute(key, value):


### PR DESCRIPTION
Datadog has issues with tagging the root span
with error information. This change adds the functionality
to tag the root span on exceptions.

This also renames the CachedCustomMonitoringMiddleware into
MonitoringSupportMiddleware so that it can be a central place
for most monitoring middleware changes instead of adding a new
one every time. At some point, CachedCustomMonitoringMiddleware
will be removed.

https://github.com/edx/edx-arch-experiments/issues/647