### PR TITLE
fix: bug when CODE_OWNER_MAPPINGS not defined

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,12 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+7.0.1 - 2024-11-21
+------------------
+Fixed
+~~~~~
+* Fix bug where code owner custom attributes were being defined, even when the CODE_OWNER_MAPPINGS setting was not defined.
+
 7.0.0 - 2024-10-16
 ------------------
 Removed

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,7 +2,7 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "7.0.0"
+__version__ = "7.0.1"
 
 default_app_config = (
     "edx_django_utils.apps.EdxDjangoUtilsConfig"

--- a/edx_django_utils/monitoring/internal/code_owner/utils.py
+++ b/edx_django_utils/monitoring/internal/code_owner/utils.py
@@ -88,7 +88,9 @@ def get_code_owner_mappings():
     # .. setting_description: Used for monitoring and reporting of ownership. Use a
     #      dict with keys of code owner name and value as a list of dotted path
     #      module names owned by the code owner.
-    code_owner_mappings = getattr(settings, 'CODE_OWNER_MAPPINGS', {})
+    code_owner_mappings = getattr(settings, 'CODE_OWNER_MAPPINGS', None)
+    if code_owner_mappings is None:
+        return None
 
     try:
         for code_owner in code_owner_mappings:

--- a/edx_django_utils/monitoring/tests/code_owner/test_middleware.py
+++ b/edx_django_utils/monitoring/tests/code_owner/test_middleware.py
@@ -231,13 +231,13 @@ class CodeOwnerMetricMiddlewareTests(TestCase):
             mock_set_custom_attribute, has_path_error=True, has_transaction_error=True
         )
 
-    @patch('edx_django_utils.monitoring.internal.code_owner.utils.set_custom_attribute')
+    @patch('edx_django_utils.monitoring.internal.code_owner.middleware.set_custom_attribute')
     def test_code_owner_no_mappings(self, mock_set_custom_attribute):
         request = RequestFactory().get('/test/')
         self.middleware(request)
         mock_set_custom_attribute.assert_not_called()
 
-    @patch('edx_django_utils.monitoring.internal.code_owner.utils.set_custom_attribute')
+    @patch('edx_django_utils.monitoring.internal.code_owner.middleware.set_custom_attribute')
     def test_code_owner_transaction_no_mappings(self, mock_set_custom_attribute):
         request = RequestFactory().get('/bad/path/')
         self.middleware(request)


### PR DESCRIPTION
**Description:**

No code_owner custom attributes should be added
when CODE_OWNER_MAPPINGS is not defined. There
was a bug in both the code and the unit tests.
This has been fixed.

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [X] Version bumped
- [X] Changelog record added
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)