### PR TITLE
Add support for kwargs in create_span method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,12 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+7.2.0 - 2025-02-03
+------------------
+Added
+~~~~~
+* Added support for passing `**kwargs` to the `create_span` method in the `TelemetryBackend` abstract class. This enables backends to accept additional span configuration options, such as custom metadata or attributes, when creating spans.
+
 7.1.0 - 2024-12-05
 ------------------
 Added

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,7 +2,7 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "7.1.0"
+__version__ = "7.2.0"
 
 default_app_config = (
     "edx_django_utils.apps.EdxDjangoUtilsConfig"

--- a/edx_django_utils/monitoring/internal/utils.py
+++ b/edx_django_utils/monitoring/internal/utils.py
@@ -95,7 +95,7 @@ def record_exception():
 
 
 @contextmanager
-def function_trace(function_name):
+def function_trace(function_name, **kwargs):
     """
     Wraps a chunk of code that we want to appear as a separate, explicit,
     segment in our monitoring tools.
@@ -106,7 +106,7 @@ def function_trace(function_name):
     # ExitStack handles the underlying context managers.
     with ExitStack() as stack:
         for backend in configured_backends():
-            context = backend.create_span(function_name)
+            context = backend.create_span(function_name, **kwargs)
             if context is not None:
                 stack.enter_context(context)
         yield


### PR DESCRIPTION
### Add support for kwargs in create_span method

Added support for passing **kwargs to the create_span method in the TelemetryBackend abstract class. This allows backends like **DatadogBackend** to accept additional arguments (e.g., resource) when creating spans.