### PR TITLE
chore: upgrade requirements

### DIFF
--- a/edx_django_utils/monitoring/tests/test_monitoring_support.py
+++ b/edx_django_utils/monitoring/tests/test_monitoring_support.py
@@ -171,7 +171,7 @@ class TestMonitoringSupportMiddleware(TestCase):
                 request='fake request', exception=fake_exception
             )
 
-    @patch('ddtrace.Tracer.current_root_span')
+    @patch('ddtrace._trace.tracer.Tracer.current_root_span')
     def test_error_tagging(self, mock_get_root_span):
         # Ensure that we continue to support tagging exceptions in MonitoringSupportMiddleware.
         # This is only implemented for DatadogBackend at the moment.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ cffi==1.17.1
     # via pynacl
 click==8.1.8
     # via -r requirements/base.in
-django==4.2.17
+django==4.2.19
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -20,11 +20,11 @@ django-crum==0.7.9
     # via -r requirements/base.in
 django-waffle==4.2.0
     # via -r requirements/base.in
-newrelic==10.4.0
+newrelic==10.6.0
     # via -r requirements/base.in
-pbr==6.1.0
+pbr==6.1.1
     # via stevedore
-psutil==6.1.1
+psutil==7.0.0
     # via -r requirements/base.in
 pycparser==2.22
     # via cffi
@@ -32,5 +32,8 @@ pynacl==1.5.0
     # via -r requirements/base.in
 sqlparse==0.5.3
     # via django
-stevedore==5.4.0
+stevedore==5.4.1
     # via -r requirements/base.in
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-cachetools==5.5.0
+cachetools==5.5.2
     # via tox
 chardet==5.2.0
     # via tox
@@ -12,7 +12,7 @@ colorama==0.4.6
     # via tox
 distlib==0.3.9
     # via virtualenv
-filelock==3.16.1
+filelock==3.17.0
     # via
     #   tox
     #   virtualenv
@@ -26,9 +26,9 @@ platformdirs==4.3.6
     #   virtualenv
 pluggy==1.5.0
     # via tox
-pyproject-api==1.8.0
+pyproject-api==1.9.0
     # via tox
-tox==4.23.2
+tox==4.24.1
     # via -r requirements/ci.in
-virtualenv==20.28.1
+virtualenv==20.29.2
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,11 +17,11 @@ build==1.2.2.post1
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-bytecode==0.16.0
+bytecode==0.16.1
     # via
     #   -r requirements/quality.txt
     #   ddtrace
-cachetools==5.5.0
+cachetools==5.5.2
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -46,7 +46,7 @@ click-log==0.4.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-code-annotations==2.1.0
+code-annotations==2.2.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -54,15 +54,15 @@ colorama==0.4.6
     # via
     #   -r requirements/ci.txt
     #   tox
-coverage[toml]==7.6.10
+coverage[toml]==7.6.12
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
 ddt==1.7.2
     # via -r requirements/quality.txt
-ddtrace==2.18.1
+ddtrace==3.0.0
     # via -r requirements/quality.txt
-deprecated==1.2.15
+deprecated==1.2.18
     # via
     #   -r requirements/quality.txt
     #   opentelemetry-api
@@ -78,7 +78,7 @@ distlib==0.3.9
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==4.2.17
+django==4.2.19
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
@@ -91,19 +91,19 @@ django-waffle==4.2.0
     # via -r requirements/quality.txt
 edx-i18n-tools==1.6.3
     # via -r requirements/dev.in
-edx-lint==5.4.1
+edx-lint==5.6.0
     # via -r requirements/quality.txt
 envier==0.6.1
     # via
     #   -r requirements/quality.txt
     #   ddtrace
-factory-boy==3.3.1
+factory-boy==3.3.3
     # via -r requirements/quality.txt
-faker==33.3.0
+faker==36.1.1
     # via
     #   -r requirements/quality.txt
     #   factory-boy
-filelock==3.16.1
+filelock==3.17.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -118,7 +118,7 @@ iniconfig==2.0.0
     # via
     #   -r requirements/quality.txt
     #   pytest
-isort==5.13.2
+isort==6.0.0
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -130,7 +130,7 @@ jinja2==3.1.5
     #   jinja2-pluralize
 jinja2-pluralize==0.3.0
     # via diff-cover
-lxml[html-clean,html_clean]==5.3.0
+lxml[html-clean,html_clean]==5.3.1
     # via
     #   edx-i18n-tools
     #   lxml-html-clean
@@ -146,11 +146,11 @@ mccabe==0.7.0
     #   pylint
 mock==5.1.0
     # via -r requirements/quality.txt
-more-itertools==10.5.0
+more-itertools==10.6.0
     # via inflect
-newrelic==10.4.0
+newrelic==10.6.0
     # via -r requirements/quality.txt
-opentelemetry-api==1.29.0
+opentelemetry-api==1.30.0
     # via
     #   -r requirements/quality.txt
     #   ddtrace
@@ -165,7 +165,7 @@ packaging==24.2
     #   tox
 path==16.16.0
     # via edx-i18n-tools
-pbr==6.1.0
+pbr==6.1.1
     # via
     #   -r requirements/quality.txt
     #   stevedore
@@ -187,11 +187,11 @@ pluggy==1.5.0
     #   tox
 polib==1.2.0
     # via edx-i18n-tools
-protobuf==5.29.2
+protobuf==5.29.3
     # via
     #   -r requirements/quality.txt
     #   ddtrace
-psutil==6.1.1
+psutil==7.0.0
     # via -r requirements/quality.txt
 pycodestyle==2.12.1
     # via -r requirements/quality.txt
@@ -201,9 +201,9 @@ pycparser==2.22
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
-pygments==2.19.0
+pygments==2.19.1
     # via diff-cover
-pylint==3.3.3
+pylint==3.3.4
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -225,7 +225,7 @@ pylint-plugin-utils==0.8.2
     #   pylint-django
 pynacl==1.5.0
     # via -r requirements/quality.txt
-pyproject-api==1.8.0
+pyproject-api==1.9.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -241,13 +241,10 @@ pytest==8.3.4
     #   pytest-django
 pytest-cov==6.0.0
     # via -r requirements/quality.txt
-pytest-django==4.9.0
+pytest-django==4.10.0
     # via -r requirements/quality.txt
 python-dateutil==2.9.0.post0
-    # via
-    #   -r requirements/dev.in
-    #   -r requirements/quality.txt
-    #   faker
+    # via -r requirements/dev.in
 python-slugify==8.0.4
     # via
     #   -r requirements/quality.txt
@@ -270,7 +267,7 @@ sqlparse==0.5.3
     # via
     #   -r requirements/quality.txt
     #   django
-stevedore==5.4.0
+stevedore==5.4.1
     # via
     #   -r requirements/quality.txt
     #   code-annotations
@@ -282,17 +279,20 @@ tomlkit==0.13.2
     # via
     #   -r requirements/quality.txt
     #   pylint
-tox==4.23.2
+tox==4.24.1
     # via -r requirements/ci.txt
-typeguard==4.4.1
+typeguard==4.4.2
     # via inflect
 typing-extensions==4.12.2
     # via
     #   -r requirements/quality.txt
     #   ddtrace
-    #   faker
     #   typeguard
-virtualenv==20.28.1
+tzdata==2025.1
+    # via
+    #   -r requirements/quality.txt
+    #   faker
+virtualenv==20.29.2
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -300,7 +300,7 @@ wheel==0.45.1
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-wrapt==1.17.0
+wrapt==1.17.2
     # via
     #   -r requirements/quality.txt
     #   ddtrace

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -12,19 +12,19 @@ asgiref==3.8.1
     # via
     #   -r requirements/test.txt
     #   django
-babel==2.16.0
+babel==2.17.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
 backports-tarfile==1.2.0
     # via jaraco-context
-beautifulsoup4==4.12.3
+beautifulsoup4==4.13.3
     # via pydata-sphinx-theme
-bytecode==0.16.0
+bytecode==0.16.1
     # via
     #   -r requirements/test.txt
     #   ddtrace
-certifi==2024.12.14
+certifi==2025.1.31
     # via requests
 cffi==1.17.1
     # via
@@ -35,21 +35,21 @@ charset-normalizer==3.4.1
     # via requests
 click==8.1.8
     # via -r requirements/test.txt
-coverage[toml]==7.6.10
+coverage[toml]==7.6.12
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==44.0.0
+cryptography==44.0.1
     # via secretstorage
 ddt==1.7.2
     # via -r requirements/test.txt
-ddtrace==2.18.1
+ddtrace==3.0.0
     # via -r requirements/test.txt
-deprecated==1.2.15
+deprecated==1.2.18
     # via
     #   -r requirements/test.txt
     #   opentelemetry-api
-django==4.2.17
+django==4.2.19
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -74,14 +74,16 @@ envier==0.6.1
     # via
     #   -r requirements/test.txt
     #   ddtrace
-factory-boy==3.3.1
+factory-boy==3.3.3
     # via
     #   -r requirements/doc.in
     #   -r requirements/test.txt
-faker==33.3.0
+faker==36.1.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
+id==1.5.0
+    # via twine
 idna==3.10
     # via requests
 imagesize==1.4.1
@@ -117,47 +119,46 @@ mdurl==0.1.2
     # via markdown-it-py
 mock==5.1.0
     # via -r requirements/test.txt
-more-itertools==10.5.0
+more-itertools==10.6.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-newrelic==10.4.0
+newrelic==10.6.0
     # via -r requirements/test.txt
 nh3==0.2.20
     # via readme-renderer
-opentelemetry-api==1.29.0
+opentelemetry-api==1.30.0
     # via
     #   -r requirements/test.txt
     #   ddtrace
 packaging==24.2
     # via
     #   -r requirements/test.txt
+    #   pydata-sphinx-theme
     #   pytest
     #   sphinx
     #   twine
-pbr==6.1.0
+pbr==6.1.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-pkginfo==1.12.0
-    # via twine
 pluggy==1.5.0
     # via
     #   -r requirements/test.txt
     #   pytest
-protobuf==5.29.2
+protobuf==5.29.3
     # via
     #   -r requirements/test.txt
     #   ddtrace
-psutil==6.1.1
+psutil==7.0.0
     # via -r requirements/test.txt
 pycparser==2.22
     # via
     #   -r requirements/test.txt
     #   cffi
-pydata-sphinx-theme==0.16.1
+pydata-sphinx-theme==0.15.4
     # via sphinx-book-theme
-pygments==2.19.0
+pygments==2.19.1
     # via
     #   accessible-pygments
     #   doc8
@@ -175,18 +176,15 @@ pytest==8.3.4
     #   pytest-django
 pytest-cov==6.0.0
     # via -r requirements/test.txt
-pytest-django==4.9.0
+pytest-django==4.10.0
     # via -r requirements/test.txt
-python-dateutil==2.9.0.post0
-    # via
-    #   -r requirements/test.txt
-    #   faker
 readme-renderer==44.0
     # via
     #   -r requirements/doc.in
     #   twine
 requests==2.32.3
     # via
+    #   id
     #   requests-toolbelt
     #   sphinx
     #   twine
@@ -198,22 +196,20 @@ rfc3986==2.0.0
     # via twine
 rich==13.9.4
     # via twine
+roman-numerals-py==3.1.0
+    # via sphinx
 secretstorage==3.3.3
     # via keyring
-six==1.17.0
-    # via
-    #   -r requirements/test.txt
-    #   python-dateutil
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.6
     # via beautifulsoup4
-sphinx==8.1.3
+sphinx==8.2.1
     # via
     #   -r requirements/doc.in
     #   pydata-sphinx-theme
     #   sphinx-book-theme
-sphinx-book-theme==1.1.3
+sphinx-book-theme==1.1.4
     # via -r requirements/doc.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -231,25 +227,30 @@ sqlparse==0.5.3
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==5.4.0
+stevedore==5.4.1
     # via
     #   -r requirements/test.txt
     #   doc8
-twine==6.0.1
+twine==6.1.0
     # via -r requirements/doc.in
 typing-extensions==4.12.2
     # via
     #   -r requirements/test.txt
+    #   beautifulsoup4
     #   ddtrace
-    #   faker
     #   pydata-sphinx-theme
-urllib3==2.3.0
+tzdata==2025.1
     # via
+    #   -r requirements/test.txt
+    #   faker
+urllib3==2.2.3
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   requests
     #   twine
 wheel==0.45.1
     # via -r requirements/doc.in
-wrapt==1.17.0
+wrapt==1.17.2
     # via
     #   -r requirements/test.txt
     #   ddtrace
@@ -262,3 +263,6 @@ zipp==3.21.0
     # via
     #   -r requirements/test.txt
     #   importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -12,5 +12,5 @@ pip==24.2
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/pip.in
-setuptools==75.7.0
+setuptools==75.8.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -12,7 +12,7 @@ astroid==3.3.8
     # via
     #   pylint
     #   pylint-celery
-bytecode==0.16.0
+bytecode==0.16.1
     # via
     #   -r requirements/test.txt
     #   ddtrace
@@ -28,23 +28,23 @@ click==8.1.8
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==2.1.0
+code-annotations==2.2.0
     # via edx-lint
-coverage[toml]==7.6.10
+coverage[toml]==7.6.12
     # via
     #   -r requirements/test.txt
     #   pytest-cov
 ddt==1.7.2
     # via -r requirements/test.txt
-ddtrace==2.18.1
+ddtrace==3.0.0
     # via -r requirements/test.txt
-deprecated==1.2.15
+deprecated==1.2.18
     # via
     #   -r requirements/test.txt
     #   opentelemetry-api
 dill==0.3.9
     # via pylint
-django==4.2.17
+django==4.2.19
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/test.txt
@@ -54,15 +54,15 @@ django-crum==0.7.9
     # via -r requirements/test.txt
 django-waffle==4.2.0
     # via -r requirements/test.txt
-edx-lint==5.4.1
+edx-lint==5.6.0
     # via -r requirements/quality.in
 envier==0.6.1
     # via
     #   -r requirements/test.txt
     #   ddtrace
-factory-boy==3.3.1
+factory-boy==3.3.3
     # via -r requirements/test.txt
-faker==33.3.0
+faker==36.1.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -74,7 +74,7 @@ iniconfig==2.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
-isort==5.13.2
+isort==6.0.0
     # via
     #   -r requirements/quality.in
     #   pylint
@@ -86,9 +86,9 @@ mccabe==0.7.0
     # via pylint
 mock==5.1.0
     # via -r requirements/test.txt
-newrelic==10.4.0
+newrelic==10.6.0
     # via -r requirements/test.txt
-opentelemetry-api==1.29.0
+opentelemetry-api==1.30.0
     # via
     #   -r requirements/test.txt
     #   ddtrace
@@ -96,7 +96,7 @@ packaging==24.2
     # via
     #   -r requirements/test.txt
     #   pytest
-pbr==6.1.0
+pbr==6.1.1
     # via
     #   -r requirements/test.txt
     #   stevedore
@@ -106,11 +106,11 @@ pluggy==1.5.0
     # via
     #   -r requirements/test.txt
     #   pytest
-protobuf==5.29.2
+protobuf==5.29.3
     # via
     #   -r requirements/test.txt
     #   ddtrace
-psutil==6.1.1
+psutil==7.0.0
     # via -r requirements/test.txt
 pycodestyle==2.12.1
     # via -r requirements/quality.in
@@ -120,7 +120,7 @@ pycparser==2.22
     #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pylint==3.3.3
+pylint==3.3.4
     # via
     #   edx-lint
     #   pylint-celery
@@ -143,28 +143,21 @@ pytest==8.3.4
     #   pytest-django
 pytest-cov==6.0.0
     # via -r requirements/test.txt
-pytest-django==4.9.0
+pytest-django==4.10.0
     # via -r requirements/test.txt
-python-dateutil==2.9.0.post0
-    # via
-    #   -r requirements/test.txt
-    #   faker
 python-slugify==8.0.4
     # via code-annotations
 pyyaml==6.0.2
     # via code-annotations
 six==1.17.0
-    # via
-    #   -r requirements/test.txt
-    #   edx-lint
-    #   python-dateutil
+    # via edx-lint
 snowballstemmer==2.2.0
     # via pydocstyle
 sqlparse==0.5.3
     # via
     #   -r requirements/test.txt
     #   django
-stevedore==5.4.0
+stevedore==5.4.1
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -176,8 +169,11 @@ typing-extensions==4.12.2
     # via
     #   -r requirements/test.txt
     #   ddtrace
+tzdata==2025.1
+    # via
+    #   -r requirements/test.txt
     #   faker
-wrapt==1.17.0
+wrapt==1.17.2
     # via
     #   -r requirements/test.txt
     #   ddtrace
@@ -190,3 +186,6 @@ zipp==3.21.0
     # via
     #   -r requirements/test.txt
     #   importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,7 +8,7 @@ asgiref==3.8.1
     # via
     #   -r requirements/base.txt
     #   django
-bytecode==0.16.0
+bytecode==0.16.1
     # via ddtrace
 cffi==1.17.1
     # via
@@ -16,13 +16,13 @@ cffi==1.17.1
     #   pynacl
 click==8.1.8
     # via -r requirements/base.txt
-coverage[toml]==7.6.10
+coverage[toml]==7.6.12
     # via pytest-cov
 ddt==1.7.2
     # via -r requirements/test.in
-ddtrace==2.18.1
+ddtrace==3.0.0
     # via -r requirements/test.in
-deprecated==1.2.15
+deprecated==1.2.18
     # via opentelemetry-api
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -35,9 +35,9 @@ django-waffle==4.2.0
     # via -r requirements/base.txt
 envier==0.6.1
     # via ddtrace
-factory-boy==3.3.1
+factory-boy==3.3.3
     # via -r requirements/test.in
-faker==33.3.0
+faker==36.1.1
     # via factory-boy
 importlib-metadata==8.5.0
     # via opentelemetry-api
@@ -45,25 +45,25 @@ iniconfig==2.0.0
     # via pytest
 mock==5.1.0
     # via -r requirements/test.in
-newrelic==10.4.0
+newrelic==10.6.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
-opentelemetry-api==1.29.0
+opentelemetry-api==1.30.0
     # via
     #   -r requirements/test.in
     #   ddtrace
 packaging==24.2
     # via pytest
-pbr==6.1.0
+pbr==6.1.1
     # via
     #   -r requirements/base.txt
     #   stevedore
 pluggy==1.5.0
     # via pytest
-protobuf==5.29.2
+protobuf==5.29.3
     # via ddtrace
-psutil==6.1.1
+psutil==7.0.0
     # via -r requirements/base.txt
 pycparser==2.22
     # via
@@ -77,23 +77,19 @@ pytest==8.3.4
     #   pytest-django
 pytest-cov==6.0.0
     # via -r requirements/test.in
-pytest-django==4.9.0
+pytest-django==4.10.0
     # via -r requirements/test.in
-python-dateutil==2.9.0.post0
-    # via faker
-six==1.17.0
-    # via python-dateutil
 sqlparse==0.5.3
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.4.0
+stevedore==5.4.1
     # via -r requirements/base.txt
 typing-extensions==4.12.2
-    # via
-    #   ddtrace
-    #   faker
-wrapt==1.17.0
+    # via ddtrace
+tzdata==2025.1
+    # via faker
+wrapt==1.17.2
     # via
     #   ddtrace
     #   deprecated
@@ -101,3 +97,6 @@ xmltodict==0.14.2
     # via ddtrace
 zipp==3.21.0
     # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools


### PR DESCRIPTION
Note that we had to update the ddtrace patch mechanism, which was no longer available in the new release.
