### PR TITLE
docs: Delete .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @edx/arch-bom


### PR DESCRIPTION
This file has been invalid for years.  Just delete it rather than correct it.