### PR TITLE
docs: bump package version to 7.4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ----------
 
+7.4.0 - 2025-04-10
+------------------
+* Same as 7.3.0
+* 7.3.0 tag was created but PyPI release job had failed
+
 7.3.0 - 2025-04-09
 ------------------
 Added

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,4 +2,4 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "7.2.0"
+__version__ = "7.4.0"


### PR DESCRIPTION
## Description
- #496 added Django 5.2 support but the PyPI version release job failed because the version had not been bumped in the `__init__.py` file. 
- Bumping the version to next iteration since the tag `7.3.0` has already been created and can/should not be deleted.