### PR TITLE
fix: Fix deprecated newrelic function calls

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ----------
 
+8.0.1 - 2025-09-29
+------------------
+* Stop using deprecated newrelic function calls that were removed in newrelic 11.0.0 (use newer names instead)
+
 8.0.0 - 2025-05-22
 ------------------
 * **BREAKING CHANGE**: ``newrelic`` removed from dependencies. Users of New Relic should install the package separately in their services. `See relevant DEPR <https://github.com/openedx/public-engineering/issues/360>`_.

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,4 +2,4 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "8.0.0"
+__version__ = "8.0.1"

--- a/edx_django_utils/monitoring/internal/backends.py
+++ b/edx_django_utils/monitoring/internal/backends.py
@@ -93,15 +93,10 @@ class NewRelicBackend(TelemetryBackend):
         # `add_custom_span_attribute` that would better match
         # OpenTelemetry's behavior, which we could try exposing
         # through a new, more specific TelemetryBackend method.
-        #
-        # TODO: Update to newer name `add_custom_attribute`
-        # https://docs.newrelic.com/docs/apm/agents/python-agent/python-agent-api/addcustomparameter-python-agent-api/
-        newrelic.agent.add_custom_parameter(key, value)
+        newrelic.agent.add_custom_attribute(key, value)
 
     def record_exception(self):
-        # TODO: Replace with newrelic.agent.notice_error()
-        # https://docs.newrelic.com/docs/apm/agents/python-agent/python-agent-api/recordexception-python-agent-api/
-        newrelic.agent.record_exception()
+        newrelic.agent.notice_error()
 
     def create_span(self, name):
         if newrelic.version_info[0] >= 5:


### PR DESCRIPTION
These shims were removed in newrelic 11.0.0.

**Merge checklist:**
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
