### PR TITLE
fix: implement OpenTelemetryBackend.create_span()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 ----------
 
+8.0.2 - 2026-08-21
+------------------
+* Implement ``OpenTelemetryBackend.create_span()``, which was previously a
+  no-op. This means ``function_trace()`` now actually creates a span for the
+  OpenTelemetry backend, matching the existing New Relic and Datadog
+  backends, instead of silently doing nothing.
+
 8.0.1 - 2025-09-29
 ------------------
 * Stop using deprecated newrelic function calls that were removed in newrelic 11.0.0 (use newer names instead)

--- a/edx_django_utils/__init__.py
+++ b/edx_django_utils/__init__.py
@@ -2,4 +2,4 @@
 EdX utilities for Django Application development..
 """
 
-__version__ = "8.0.1"
+__version__ = "8.0.2"

--- a/edx_django_utils/monitoring/internal/backends.py
+++ b/edx_django_utils/monitoring/internal/backends.py
@@ -124,6 +124,7 @@ class OpenTelemetryBackend(TelemetryBackend):
         # If import fails, the backend won't be used.
         from opentelemetry import trace
         self.otel_trace = trace
+        self.otel_tracer = trace.get_tracer(__name__)
 
     def set_attribute(self, key, value):
         # Sets the value on the current span, not necessarily the root
@@ -134,8 +135,12 @@ class OpenTelemetryBackend(TelemetryBackend):
         self.otel_trace.get_current_span().record_exception(sys.exc_info()[1])
 
     def create_span(self, name):
-        # Currently, this is not implemented.
-        pass
+        # Returns a new child span parented to the current span (or a new
+        # root span if none is active), matching the other backends'
+        # behavior. The caller is responsible for entering/exiting the
+        # returned context manager, same as with NewRelicBackend and
+        # DatadogBackend.
+        return self.otel_tracer.start_as_current_span(name)
 
     def tag_root_span_with_error(self, exception):
         # Currently, this is not implemented for OTel

--- a/edx_django_utils/monitoring/tests/test_backends.py
+++ b/edx_django_utils/monitoring/tests/test_backends.py
@@ -7,7 +7,7 @@ import ddt
 import pytest
 from django.test import TestCase, override_settings
 
-from edx_django_utils.monitoring import record_exception, set_custom_attribute
+from edx_django_utils.monitoring import function_trace, record_exception, set_custom_attribute
 from edx_django_utils.monitoring.internal.backends import configured_backends
 
 
@@ -151,3 +151,24 @@ class TestBackendsFanOut(TestCase):
         mock_nr_notice_error.assert_called_once()
         mock_otel_record_exception.assert_called_once()
         mock_dd_span.assert_called_once()
+
+    @patch('newrelic.agent.FunctionTrace')
+    @patch('opentelemetry.trace.NoOpTracer.start_as_current_span')
+    # Same reasoning as test_set_custom_attribute: patch the concrete
+    # no-op tracer's method, since get_tracer() only returns something
+    # usable once called, and there's no active provider in this test.
+    @patch('ddtrace._trace.tracer.Tracer.trace')
+    def test_create_span(
+            self, mock_dd_trace,
+            mock_otel_start_span, mock_nr_function_trace,
+    ):
+        with override_settings(OPENEDX_TELEMETRY=[
+                'edx_django_utils.monitoring.NewRelicBackend',
+                'edx_django_utils.monitoring.OpenTelemetryBackend',
+                'edx_django_utils.monitoring.DatadogBackend',
+        ]):
+            with function_trace('some_function_name'):
+                pass
+        mock_nr_function_trace.assert_called_once_with('some_function_name')
+        mock_otel_start_span.assert_called_once_with('some_function_name')
+        mock_dd_trace.assert_called_once_with('some_function_name')


### PR DESCRIPTION
**Description:**

`OpenTelemetryBackend.create_span()` is currently a no-op (`pass`, implicitly returns `None`). `function_trace()` in `monitoring/internal/utils.py` handles that by simply skipping the context manager when a backend's `create_span()` returns `None`:

```python
context = backend.create_span(function_name)
if context is not None:
    stack.enter_context(context)
```

So with `OPENEDX_TELEMETRY = ['edx_django_utils.monitoring.OpenTelemetryBackend']`, every `function_trace()` call site across a consuming service silently does nothing for OTel -- no span is created, no error is raised. Both `NewRelicBackend.create_span()` and `DatadogBackend.create_span()` already return real spans/context managers.

This PR implements it the same way, using `tracer.start_as_current_span(name)`.

**JIRA:**

N/A

**Dependencies:**

None.

**Testing instructions:**

`OpenTelemetryBackend.create_span()` was previously untested against any real behavior -- the existing OTel test coverage in `test_backends.py` patches `NonRecordingSpan.set_attribute`/`record_exception` directly (per the test's own comment: "it doesn't give us a span unless one is active. And I didn't feel like setting that up"), and no test exercised `create_span()`/`function_trace()` for any backend at all.

Added `test_create_span`, following the file's existing fan-out-across-backends pattern (`test_set_custom_attribute`, `test_record_exception`), calling `function_trace()` with all three backends configured and asserting each one's underlying span/trace method gets called with the function name. Ran the full `monitoring` test suite locally: 90 passed. Also ran `pycodestyle`/`isort` against the changed files -- clean.

**Author concerns:**

`tag_root_span_with_error()` and `set_local_root_span_name()` are also currently unimplemented for `OpenTelemetryBackend` (both `pass`). I didn't touch those here -- `create_span()` was the one with an existing consumer (`function_trace()`, used at ~80 call sites in `edx-platform`) producing a silent behavior gap; the other two didn't have an obvious "correct" OTel mapping worth guessing at in the same PR. Happy to follow up if there's interest.