### PR TITLE
feat: Add deprecation warning to code owner celery task decorator

### DIFF
--- a/edx_django_utils/monitoring/internal/code_owner/utils.py
+++ b/edx_django_utils/monitoring/internal/code_owner/utils.py
@@ -3,6 +3,7 @@ Utilities for monitoring code_owner
 """
 import logging
 import re
+import warnings
 from functools import wraps
 
 from django.conf import settings
@@ -139,11 +140,23 @@ def set_code_owner_attribute_from_module(module):
     Note: These settings will be overridden by the CodeOwnerMonitoringMiddleware.
         This method can't be used to override web functions at this time.
 
+    .. deprecated::
+        This functionality (and the ``set_code_owner_attribute`` decorator that
+        uses it) is deprecated and will be removed. See
+        `DEPR: Code Owner Monitoring <https://github.com/openedx/edx-django-utils/issues/469>`_.
+
     Usage::
 
         set_code_owner_attribute_from_module(__name__)
 
     """
+    warnings.warn(
+        "set_code_owner_attribute_from_module and set_code_owner_attribute are deprecated and will be "
+        "removed. See https://github.com/openedx/edx-django-utils/issues/469 for details.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    set_custom_attribute('deprecated_code_owner_celery_monitoring', module)
     set_custom_attribute('code_owner_module', module)
     code_owner = get_code_owner_from_module(module)
     if not code_owner:
@@ -174,6 +187,10 @@ def set_code_owner_attribute(wrapped_function):
 
     Celery tasks or other non-web functions do not use middleware, so we need
         an alternative way to set the code_owner custom attribute.
+
+    .. deprecated::
+        This decorator is deprecated and will be removed. See
+        `DEPR: Code Owner Monitoring <https://github.com/openedx/edx-django-utils/issues/469>`_.
 
     Usage::
 

--- a/edx_django_utils/monitoring/tests/code_owner/test_utils.py
+++ b/edx_django_utils/monitoring/tests/code_owner/test_utils.py
@@ -132,6 +132,21 @@ class MonitoringUtilsTests(TestCase):
         set_code_owner_attribute_from_module(__name__)
         self._assert_set_custom_attribute(mock_set_custom_attribute, code_owner='team-red', module=__name__)
 
+    def test_set_code_owner_attribute_deprecation_warning(self):
+        with self.assertWarns(DeprecationWarning):
+            decorated_function('test')
+
+    def test_set_code_owner_attribute_from_module_deprecation_warning(self):
+        with self.assertWarns(DeprecationWarning):
+            set_code_owner_attribute_from_module(__name__)
+
+    @patch('edx_django_utils.monitoring.internal.code_owner.utils.set_custom_attribute')
+    def test_set_code_owner_attribute_from_module_deprecated_custom_attribute(self, mock_set_custom_attribute):
+        set_code_owner_attribute_from_module(__name__)
+        mock_set_custom_attribute.assert_has_calls(
+            [call('deprecated_code_owner_celery_monitoring', __name__)], any_order=True
+        )
+
     def _assert_set_custom_attribute(self, mock_set_custom_attribute, code_owner, module, check_theme_and_squad=False):
         """
         Helper to assert that the proper set_custom_metric calls were made.


### PR DESCRIPTION
Adds a DeprecationWarning and a monitoring custom attribute to set_code_owner_attribute / set_code_owner_attribute_from_module, to signal the upcoming removal and give visibility into which callers still use it before it is removed.

Refs openedx/edx-django-utils#469

**Description:**

Adds a `DeprecationWarning` and a `deprecated_code_owner_celery_monitoring` monitoring custom attribute inside `set_code_owner_attribute` / `set_code_owner_attribute_from_module`. This is purely additive (no behavior change) and gives downstream teams a signal, plus dashboard visibility into which modules still call the decorator, ahead of its eventual removal.

**JIRA:**

openedx/edx-django-utils#469

**Dependencies:**

None. 

**Merge deadline:**

None currently. The Willow branch cut was delayed to early January 2027, so there's no immediate deadline pressure on this change.

**Installation instructions:**

None.

**Testing instructions:**

1. Decorate a function with `@set_code_owner_attribute` (or call `set_code_owner_attribute_from_module` directly).
2. Call the decorated function.
3. Expect a `DeprecationWarning` to be raised, and a `deprecated_code_owner_celery_monitoring` custom attribute to be set with the calling module name.
4. If no warning is raised, or the custom attribute is missing - check failed. See `test_set_code_owner_attribute_deprecation_warning`, `test_set_code_owner_attribute_from_module_deprecation_warning`, and `test_set_code_owner_attribute_from_module_deprecated_custom_attribute` in `test_utils.py`.

**Reviewers:**
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
**Author concerns:**

List any concerns about this PR - inelegant
solutions, hacks, quick-and-dirty implementations, concerns about
migrations, etc.
